### PR TITLE
[codex] Break controlplane import cycle

### DIFF
--- a/wm_infra/controlplane/__init__.py
+++ b/wm_infra/controlplane/__init__.py
@@ -6,7 +6,9 @@ The control plane tracks what was requested, what was produced,
 and how outputs can flow into evaluation and training.
 """
 
-from .resource_estimator import estimate_rollout_request, estimate_wan_request
+from importlib import import_module
+from typing import TYPE_CHECKING
+
 from .schemas import (
     ArtifactKind,
     ArtifactRecord,
@@ -47,6 +49,21 @@ from .temporal import (
     TemporalStatus,
     TemporalStore,
 )
+
+if TYPE_CHECKING:
+    from .resource_estimator import estimate_rollout_request, estimate_wan_request
+
+_RESOURCE_ESTIMATOR_EXPORTS = {"estimate_rollout_request", "estimate_wan_request"}
+
+
+def __getattr__(name: str):
+    if name in _RESOURCE_ESTIMATOR_EXPORTS:
+        module = import_module(".resource_estimator", __name__)
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "ArtifactKind",


### PR DESCRIPTION
This PR removes the eager `resource_estimator` import from `wm_infra.controlplane.__init__` and exposes the estimator helpers lazily via `__getattr__`.

Why:
- `wm_infra.core.scheduler` imports `wm_infra.controlplane.schemas`, which imports the control-plane package.
- The package initializer was importing `resource_estimator`, which imported `scheduler` again and created a circular import during test collection.

Impact:
- `tests/test_engine.py` can now import and collect cleanly.
- The control-plane package still exports `estimate_rollout_request` and `estimate_wan_request` from its top level, but without forcing the runtime dependency chain during package import.

Validation:
- `pytest tests/test_engine.py`
- `pytest tests/test_controlplane.py`