### PR TITLE
[codex] Add benchmark baseline metadata

### DIFF
--- a/benchmarks/bench_samples_api.py
+++ b/benchmarks/bench_samples_api.py
@@ -23,7 +23,7 @@ import httpx
 from asgi_lifespan import LifespanManager
 
 from wm_infra.api.server import create_app
-from wm_infra.benchmarking import run_summary_from_samples, utc_timestamp, write_json
+from wm_infra.benchmarking import capture_runtime_context, comparison_report, load_json, run_summary_from_samples, utc_timestamp, write_json
 from wm_infra.config import ControlPlaneConfig, DynamicsConfig, EngineConfig, StateCacheConfig, TokenizerConfig
 from wm_infra.controlplane import SampleManifestStore
 
@@ -164,6 +164,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--system-name", default="wm-infra")
     parser.add_argument("--runner-name", default="unknown")
     parser.add_argument("--output", default="benchmarks/results/sample_api_benchmark.json")
+    parser.add_argument("--baseline-file", help="Optional benchmark JSON file to compare against and embed in the output artifact")
     return parser.parse_args()
 
 
@@ -189,10 +190,21 @@ async def _main_async() -> None:
     result = {
         "schema_version": 1,
         "recorded_at": utc_timestamp(),
+        "run_context": capture_runtime_context(),
         "system": {
             "name": args.system_name,
             "runner": args.runner_name,
             "execution_mode": execution_mode,
+        },
+        "execution": {
+            "mode": execution_mode,
+            "iterations": args.iterations,
+            "concurrency": args.concurrency,
+            "timeout_s": args.timeout_s,
+            "base_url": args.base_url,
+            "in_process": args.in_process,
+            "workload": args.workload,
+            "payload_file": args.payload_file,
         },
         "workload": {
             "workload_kind": "sample_api",
@@ -215,6 +227,14 @@ async def _main_async() -> None:
             "Comparisons against vLLM or sglang are only valid when the workload definition matches and the external system can actually execute that workload.",
         ],
     }
+    if args.baseline_file:
+        baseline = load_json(args.baseline_file)
+        result["baseline"] = {
+            "path": args.baseline_file,
+            "recorded_at": baseline.get("recorded_at"),
+            "system": baseline.get("system"),
+            "comparison": comparison_report(result, baseline),
+        }
     write_json(args.output, result)
     print(f"Wrote benchmark artifact to {args.output}")
     print(summary)

--- a/benchmarks/compare_runs.py
+++ b/benchmarks/compare_runs.py
@@ -10,25 +10,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from wm_infra.benchmarking import comparable_run_pair, load_json
-
-
-METRICS = [
-    ("submit_mean_ms", ("summary", "latency", "submit", "mean_ms")),
-    ("submit_p95_ms", ("summary", "latency", "submit", "p95_ms")),
-    ("terminal_mean_ms", ("summary", "latency", "terminal", "mean_ms")),
-    ("terminal_p95_ms", ("summary", "latency", "terminal", "p95_ms")),
-    ("success_rate", ("summary", "success_rate")),
-]
-
-
-def _dig(payload, path):
-    cur = payload
-    for key in path:
-        if not isinstance(cur, dict) or key not in cur:
-            return None
-        cur = cur[key]
-    return cur
+from wm_infra.benchmarking import comparison_report, load_json
 
 
 def parse_args():
@@ -43,10 +25,10 @@ def main() -> int:
     left = load_json(args.left)
     right = load_json(args.right)
 
-    ok, mismatches = comparable_run_pair(left, right)
-    if not ok:
+    report = comparison_report(right, left)
+    if not report["comparable"]:
         print("Runs are not comparable. Mismatched workload axes:")
-        for mismatch in mismatches:
+        for mismatch in report["mismatches"]:
             print(f"- {mismatch}")
         return 2
 
@@ -54,11 +36,11 @@ def main() -> int:
     right_name = right.get("system", {}).get("name", args.right)
     print(f"Comparable workload confirmed: {left.get('workload', {})}")
     print(f"{'metric':<20} {'left':>12} {'right':>12} {'delta(right-left)':>18}")
-    for name, path in METRICS:
-        lval = _dig(left, path)
-        rval = _dig(right, path)
-        delta = None if lval is None or rval is None else (float(rval) - float(lval))
-        print(f"{name:<20} {str(lval):>12} {str(rval):>12} {str(round(delta, 3) if delta is not None else None):>18}")
+    for name, values in report["metrics"].items():
+        lval = values["baseline"]
+        rval = values["current"]
+        delta = values["delta"]
+        print(f"{name:<20} {str(lval):>12} {str(rval):>12} {str(round(delta, 3)):>18}")
     print(f"left={left_name}  right={right_name}")
     return 0
 

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -41,6 +41,19 @@ This measures:
 - polling counts until completion
 - per-iteration status and terminal payloads
 - aggregated p50 / p95 / p99 latency summaries
+- reproducibility metadata such as Python, platform, and git context
+
+To embed a baseline comparison directly into the artifact, add `--baseline-file`:
+
+```bash
+python benchmarks/bench_samples_api.py \
+  --in-process \
+  --workload wan \
+  --iterations 5 \
+  --baseline-file benchmarks/results/wan-baseline.json
+```
+
+When the baseline and current run share the same workload axes, the artifact includes metric deltas for submit latency, terminal latency, and success rate.
 
 The output is written to a structured JSON artifact under `benchmarks/results/` by default.
 
@@ -48,7 +61,9 @@ The output is written to a structured JSON artifact under `benchmarks/results/` 
 
 Benchmark outputs follow a simple structured schema:
 - `system`: who produced the run (`wm-infra`, `vllm`, `sglang`, etc.)
+- `run_context`: runtime, platform, and git metadata captured at benchmark time
 - `workload`: canonical workload definition used for comparability checks
+- `baseline`: optional embedded comparison against a prior run file
 - `summary`: aggregated counts and latency stats
 - `samples`: raw per-iteration observations
 

--- a/tests/test_benchmarking.py
+++ b/tests/test_benchmarking.py
@@ -1,4 +1,4 @@
-from wm_infra.benchmarking import comparable_run_pair, percentile, run_summary_from_samples, summarize_latency_ms
+from wm_infra.benchmarking import capture_runtime_context, comparable_run_pair, comparison_report, percentile, run_summary_from_samples, summarize_latency_ms
 
 
 def test_percentile_interpolates():
@@ -58,3 +58,59 @@ def test_comparable_run_pair_rejects_mismatched_workloads():
     ok, mismatches = comparable_run_pair(left, right)
     assert ok is False
     assert any("frame_count" in item for item in mismatches)
+
+
+def test_capture_runtime_context_includes_reproducibility_metadata():
+    context = capture_runtime_context()
+    assert "captured_at" in context
+    assert context["python"]["version"]
+    assert context["python"]["implementation"]
+    assert context["platform"]["system"]
+    assert set(context["git"]) >= {"commit", "branch", "remote", "dirty"}
+
+
+def test_comparison_report_embeds_metric_deltas():
+    baseline = {
+        "workload": {
+            "workload_kind": "sample_api",
+            "task_type": "text_to_video",
+            "backend_family": "wan-video",
+            "model": "wan2.2-t2v-A14B",
+            "frame_count": 9,
+            "width": 832,
+            "height": 480,
+            "num_steps": 4,
+        },
+        "summary": {
+            "latency": {
+                "submit": {"mean_ms": 10.0, "p95_ms": 12.0},
+                "terminal": {"mean_ms": 100.0, "p95_ms": 120.0},
+            },
+            "success_rate": 0.5,
+        },
+    }
+    current = {
+        "workload": {
+            "workload_kind": "sample_api",
+            "task_type": "text_to_video",
+            "backend_family": "wan-video",
+            "model": "wan2.2-t2v-A14B",
+            "frame_count": 9,
+            "width": 832,
+            "height": 480,
+            "num_steps": 4,
+        },
+        "summary": {
+            "latency": {
+                "submit": {"mean_ms": 14.0, "p95_ms": 16.0},
+                "terminal": {"mean_ms": 90.0, "p95_ms": 110.0},
+            },
+            "success_rate": 1.0,
+        },
+    }
+
+    report = comparison_report(current, baseline)
+    assert report["comparable"] is True
+    assert report["metrics"]["submit_mean_ms"]["delta"] == 4.0
+    assert report["metrics"]["terminal_mean_ms"]["delta"] == -10.0
+    assert report["metrics"]["success_rate"]["delta"] == 0.5

--- a/wm_infra/benchmarking.py
+++ b/wm_infra/benchmarking.py
@@ -7,18 +7,30 @@ systems such as wm-infra, vLLM, and sglang.
 
 from __future__ import annotations
 
+import json
+import platform
+import subprocess
+import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from statistics import mean
 from typing import Any
-import json
 
 
 @dataclass(frozen=True)
 class ComparableAxis:
     name: str
     value: Any
+
+
+_COMPARISON_METRICS = [
+    ("submit_mean_ms", ("summary", "latency", "submit", "mean_ms")),
+    ("submit_p95_ms", ("summary", "latency", "submit", "p95_ms")),
+    ("terminal_mean_ms", ("summary", "latency", "terminal", "mean_ms")),
+    ("terminal_p95_ms", ("summary", "latency", "terminal", "p95_ms")),
+    ("success_rate", ("summary", "success_rate")),
+]
 
 
 def utc_timestamp() -> str:
@@ -81,6 +93,62 @@ def canonical_workload_key(workload: dict[str, Any]) -> dict[str, Any]:
     return {key: workload.get(key) for key in keys if workload.get(key) is not None}
 
 
+def _dig(payload: dict[str, Any], path: tuple[str, ...]) -> Any:
+    cur: Any = payload
+    for key in path:
+        if not isinstance(cur, dict) or key not in cur:
+            return None
+        cur = cur[key]
+    return cur
+
+
+def _run_git(args: list[str], cwd: Path) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=2.0,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, OSError):
+        return None
+    if completed.returncode != 0:
+        return None
+    value = completed.stdout.strip()
+    return value or None
+
+
+def capture_runtime_context(cwd: str | Path | None = None) -> dict[str, Any]:
+    root = Path(cwd) if cwd is not None else Path.cwd()
+    git_commit = _run_git(["rev-parse", "HEAD"], root)
+    git_branch = _run_git(["branch", "--show-current"], root)
+    git_remote = _run_git(["remote", "get-url", "origin"], root)
+    git_dirty = _run_git(["status", "--short"], root)
+    return {
+        "captured_at": utc_timestamp(),
+        "python": {
+            "implementation": platform.python_implementation(),
+            "version": sys.version.split()[0],
+            "executable": sys.executable,
+        },
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "version": platform.version(),
+            "machine": platform.machine(),
+            "processor": platform.processor(),
+        },
+        "git": {
+            "commit": git_commit,
+            "branch": git_branch,
+            "remote": git_remote,
+            "dirty": bool(git_dirty),
+        },
+    }
+
+
 def comparable_run_pair(left: dict[str, Any], right: dict[str, Any]) -> tuple[bool, list[str]]:
     left_key = canonical_workload_key(left.get("workload", {}))
     right_key = canonical_workload_key(right.get("workload", {}))
@@ -89,6 +157,37 @@ def comparable_run_pair(left: dict[str, Any], right: dict[str, Any]) -> tuple[bo
         if left_key.get(key) != right_key.get(key):
             mismatches.append(f"{key}: {left_key.get(key)!r} != {right_key.get(key)!r}")
     return len(mismatches) == 0, mismatches
+
+
+def comparison_report(current: dict[str, Any], baseline: dict[str, Any]) -> dict[str, Any]:
+    ok, mismatches = comparable_run_pair(baseline, current)
+    report: dict[str, Any] = {
+        "comparable": ok,
+        "mismatches": mismatches,
+        "baseline_workload": canonical_workload_key(baseline.get("workload", {})),
+        "current_workload": canonical_workload_key(current.get("workload", {})),
+        "metrics": {},
+    }
+    if not ok:
+        return report
+
+    metrics: dict[str, Any] = {}
+    for metric_name, path in _COMPARISON_METRICS:
+        base_value = _dig(baseline, path)
+        current_value = _dig(current, path)
+        if base_value is None or current_value is None:
+            continue
+        base_f = float(base_value)
+        current_f = float(current_value)
+        delta = current_f - base_f
+        metrics[metric_name] = {
+            "baseline": base_f,
+            "current": current_f,
+            "delta": delta,
+            "delta_pct": (delta / base_f * 100.0) if base_f else None,
+        }
+    report["metrics"] = metrics
+    return report
 
 
 def run_summary_from_samples(samples: list[dict[str, Any]]) -> dict[str, Any]:


### PR DESCRIPTION
## What changed
- Added reproducibility metadata to benchmark artifacts via `run_context`.
- Added optional `--baseline-file` support to the sample benchmark harness so a current Wan run can embed a comparable baseline comparison directly into the output JSON.
- Centralized comparison logic in `wm_infra/benchmarking.py` and updated the benchmark comparison script to reuse it.
- Expanded benchmark tests to cover runtime metadata capture and metric delta reporting.

## Why
- The benchmark output now preserves enough context to support the AGENTS.md measurement loop: run, record, compare, and iterate on the same workload definition.
- Baseline comparisons are now carried alongside the artifact instead of living only in ad hoc notes or external scripts.

## Validation
- `pytest tests/test_benchmarking.py`