### PR TITLE
[codex] Fallback Genie to stub on real failures

### DIFF
--- a/tests/test_genie.py
+++ b/tests/test_genie.py
@@ -101,6 +101,37 @@ class TestGenieRunner:
         assert result.elapsed_s >= 0
         assert result.error is None
 
+    def test_real_mode_failure_falls_back_to_stub(self, tmp_path, monkeypatch):
+        runner = GenieRunner()
+        runner._mode = "real"
+        runner._model = object()
+
+        def fake_run_real(output_dir, prompt, seed, num_frames, input_tokens):
+            return GenieRunResult(
+                mode="real",
+                tokens_generated=0,
+                frames_generated=0,
+                prompt_frames=8,
+                total_frames=16,
+                spatial_h=16,
+                spatial_w=16,
+                vocab_size=262144,
+                elapsed_s=0.1,
+                model_name="genie-local",
+                device="cuda",
+                error="unsupported device",
+            )
+
+        monkeypatch.setattr(runner, "_run_real", fake_run_real)
+
+        result = runner.run(output_dir=tmp_path / "out", prompt="fallback", seed=7, num_frames=16)
+        assert result.mode == "stub"
+        assert result.error is None
+        assert result.extra["fallback_from"] == "real"
+        assert result.extra["fallback_error"] == "unsupported device"
+        tokens = np.load(result.tokens_path)
+        assert tokens.shape == (result.total_frames, result.spatial_h, result.spatial_w)
+
 
 # ---------------------------------------------------------------------------
 # GenieRolloutBackend unit tests

--- a/wm_infra/backends/genie.py
+++ b/wm_infra/backends/genie.py
@@ -218,8 +218,6 @@ class GenieRolloutBackend(ProduceSampleBackend):
         request_path.write_text(json.dumps(request_payload, indent=2, sort_keys=True))
 
         started_at = time.time()
-        mode = self._runner.mode
-
         rollout = self.temporal_store.create_rollout(
             RolloutCreate(
                 episode_id=episode.episode_id,
@@ -232,7 +230,7 @@ class GenieRolloutBackend(ProduceSampleBackend):
                 step_count=step_count,
                 priority=request.priority,
                 metadata={
-                    "runner_mode": mode,
+                    "runner_mode": self._runner.mode,
                     "prompt": request.sample_spec.prompt,
                     "controls": request.sample_spec.controls,
                     "token_input": token_input_runtime,
@@ -249,12 +247,23 @@ class GenieRolloutBackend(ProduceSampleBackend):
             num_frames=num_frames,
             input_tokens=input_tokens,
         )
+        mode = run_result.mode
+        request_payload["runner_mode"] = mode
+        if run_result.extra.get("fallback_from"):
+            request_payload["fallback_from"] = run_result.extra["fallback_from"]
+            request_payload["fallback_error"] = run_result.extra.get("fallback_error")
+        request_path.write_text(json.dumps(request_payload, indent=2, sort_keys=True))
 
         status = SampleStatus.SUCCEEDED
         error_info: str | None = None
         if run_result.error:
             status = SampleStatus.FAILED
             error_info = run_result.error
+
+        rollout.metadata["runner_mode"] = mode
+        if run_result.extra.get("fallback_from"):
+            rollout.metadata["fallback_from"] = run_result.extra["fallback_from"]
+            rollout.metadata["fallback_error"] = run_result.extra.get("fallback_error")
 
         log_lines = [
             f"Genie runner mode: {mode}",
@@ -269,6 +278,8 @@ class GenieRolloutBackend(ProduceSampleBackend):
             log_lines.append("MAGVIT2 scaffold present: raw token path accepted; native MAGVIT2 tokenization is not implemented yet.")
         if run_result.error:
             log_lines.append(f"ERROR: {run_result.error}")
+        if run_result.extra.get("fallback_from"):
+            log_lines.append(f"FALLBACK: {run_result.extra['fallback_from']} -> {mode}")
         log_path.write_text("\n".join(log_lines) + "\n")
 
         state_uri = f"file://{run_result.tokens_path}" if run_result.tokens_path else None
@@ -478,6 +489,9 @@ class GenieRolloutBackend(ProduceSampleBackend):
             "completed_at": completed_at,
             "elapsed_ms": round((completed_at - started_at) * 1000, 2),
         }
+        if run_result.extra.get("fallback_from"):
+            runtime["fallback_from"] = run_result.extra["fallback_from"]
+            runtime["fallback_error"] = run_result.extra.get("fallback_error")
         if error_info:
             runtime["error"] = error_info
         runtime_path.write_text(json.dumps(runtime, indent=2, sort_keys=True))
@@ -511,6 +525,7 @@ class GenieRolloutBackend(ProduceSampleBackend):
                 "priority": request.priority,
                 "labels": request.labels,
                 "runner_mode": mode,
+                "fallback_from": run_result.extra.get("fallback_from"),
                 "stubbed": mode == "stub",
                 "async": False,
                 "notes": (

--- a/wm_infra/backends/genie_runner.py
+++ b/wm_infra/backends/genie_runner.py
@@ -198,7 +198,22 @@ class GenieRunner:
         output_dir.mkdir(parents=True, exist_ok=True)
 
         if self._mode == "real" and self._model is not None:
-            return self._run_real(output_dir, prompt, seed, num_frames, input_tokens)
+            result = self._run_real(output_dir, prompt, seed, num_frames, input_tokens)
+            if result.error:
+                logger.warning(
+                    "Genie real-mode execution failed; falling back to stub mode: %s",
+                    result.error,
+                )
+                self._mode = "stub"
+                fallback = self._run_stub(output_dir, prompt, seed, num_frames, input_tokens)
+                fallback.extra.update(
+                    {
+                        "fallback_from": "real",
+                        "fallback_error": result.error,
+                    }
+                )
+                return fallback
+            return result
         return self._run_stub(output_dir, prompt, seed, num_frames, input_tokens)
 
     # ------------------------------------------------------------------

--- a/wm_infra/controlplane/__init__.py
+++ b/wm_infra/controlplane/__init__.py
@@ -6,7 +6,9 @@ The control plane tracks what was requested, what was produced,
 and how outputs can flow into evaluation and training.
 """
 
-from .resource_estimator import estimate_rollout_request, estimate_wan_request
+from importlib import import_module
+from typing import TYPE_CHECKING
+
 from .schemas import (
     ArtifactKind,
     ArtifactRecord,
@@ -47,6 +49,21 @@ from .temporal import (
     TemporalStatus,
     TemporalStore,
 )
+
+if TYPE_CHECKING:
+    from .resource_estimator import estimate_rollout_request, estimate_wan_request
+
+_RESOURCE_ESTIMATOR_EXPORTS = {"estimate_rollout_request", "estimate_wan_request"}
+
+
+def __getattr__(name: str):
+    if name in _RESOURCE_ESTIMATOR_EXPORTS:
+        module = import_module(".resource_estimator", __name__)
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "ArtifactKind",


### PR DESCRIPTION
This change makes Genie degrade cleanly to stub mode when real-mode execution loads but cannot run on the current machine.

What changed:
- `GenieRunner.run()` now falls back to deterministic stub output when real execution returns an error.
- The Genie backend records the effective mode from the run result, so runtime JSON, rollout metadata, and logs reflect the actual operating mode instead of the pre-load mode.
- A regression test covers the real-mode-failure fallback path.

Why:
- On this machine, Genie dependencies can import successfully but real execution fails later in attention kernels. That previously produced failed sample records even though the workload could still be represented as a stubbed temporal sample.

Checks:
- `pytest tests/test_genie.py`
- `pytest tests/test_server.py -k 'create_temporal_entities_and_genie_rollout or genie_rollout_artifact_content_downloadable or genie_rollout_accepts_inline_raw_tokens'`