### PR TITLE
[codex] Make Wan stub mode truthful

### DIFF
--- a/tests/test_benchmarking.py
+++ b/tests/test_benchmarking.py
@@ -18,16 +18,18 @@ def test_summarize_latency_ms():
 def test_run_summary_from_samples():
     summary = run_summary_from_samples([
         {"status": "succeeded", "metrics": {"submit_latency_ms": 10, "terminal_latency_ms": 100}},
+        {"status": "accepted", "metrics": {"submit_latency_ms": 15, "terminal_latency_ms": 150}},
         {"status": "failed", "metrics": {"submit_latency_ms": 20, "terminal_latency_ms": 200}},
         {"status": "queued", "metrics": {"submit_latency_ms": 30}},
     ])
-    assert summary["counts"]["total"] == 3
+    assert summary["counts"]["total"] == 4
     assert summary["counts"]["succeeded"] == 1
+    assert summary["counts"]["accepted"] == 1
     assert summary["counts"]["failed"] == 1
     assert summary["counts"]["queued"] == 1
     assert summary["latency"]["submit"]["p95_ms"] > 0
-    assert summary["latency"]["terminal"]["count"] == 2.0
-    assert summary["success_rate"] == 1 / 3
+    assert summary["latency"]["terminal"]["count"] == 3.0
+    assert summary["success_rate"] == 2 / 4
 
 
 def test_comparable_run_pair_rejects_mismatched_workloads():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -72,7 +72,7 @@ async def _wait_for_terminal_sample(client: httpx.AsyncClient, sample_id: str, t
         resp = await client.get(f"/v1/samples/{sample_id}")
         assert resp.status_code == 200
         last = resp.json()
-        if last["status"] in {"succeeded", "failed"}:
+        if last["status"] in {"succeeded", "failed", "accepted"}:
             return last
         await asyncio.sleep(0.05)
     raise AssertionError(f"sample {sample_id} did not reach terminal state; last={last}")
@@ -280,11 +280,13 @@ class TestSamples:
         assert resp.json()["status"] == "queued"
 
         final = await _wait_for_terminal_sample(client, sample_id)
-        assert final["status"] == "succeeded"
+        assert final["status"] == "accepted"
         assert final["runtime"]["runner"] == "stub"
         assert final["runtime"]["elapsed_ms"] >= 0
         kinds = {a["kind"] for a in final["artifacts"]}
-        assert {"video", "log", "metadata"}.issubset(kinds)
+        assert "video" not in kinds
+        assert {"log", "metadata"}.issubset(kinds)
+        assert final["metadata"]["stubbed"] is True
 
     @pytest.mark.asyncio
     async def test_create_wan_video_requires_prompt_for_t2v(self, client):
@@ -370,11 +372,14 @@ class TestArtifacts:
         })
         sample_id = resp.json()["sample_id"]
         data = await _wait_for_terminal_sample(client, sample_id)
-        assert data["status"] == "succeeded"
+        assert data["status"] == "accepted"
 
         art_resp = await client.get(f"/v1/samples/{sample_id}/artifacts")
         assert art_resp.status_code == 200
-        assert art_resp.json()["count"] >= 3
+        artifact_kinds = {artifact["kind"] for artifact in art_resp.json()["artifacts"]}
+        assert {"log", "metadata"}.issubset(artifact_kinds)
+        assert "video" not in artifact_kinds
+        assert art_resp.json()["count"] == len(art_resp.json()["artifacts"])
 
     @pytest.mark.asyncio
     async def test_get_artifact_metadata(self, client):
@@ -389,7 +394,7 @@ class TestArtifacts:
         sample_id = resp.json()["sample_id"]
 
         data = await _wait_for_terminal_sample(client, sample_id)
-        assert data["status"] == "succeeded"
+        assert data["status"] == "accepted"
 
         # Fetch log artifact metadata
         log_artifact_id = quote(f"{sample_id}:log", safe="")

--- a/tests/test_wan_truthfulness.py
+++ b/tests/test_wan_truthfulness.py
@@ -1,0 +1,28 @@
+"""Focused tests for Wan backend truthfulness in stub mode."""
+
+import pytest
+
+from wm_infra.backends.wan import WanVideoBackend
+from wm_infra.controlplane import ArtifactKind, ProduceSampleRequest, SampleSpec, SampleStatus, TaskType
+
+
+@pytest.mark.asyncio
+async def test_stub_mode_does_not_emit_video_artifact(tmp_path):
+    backend = WanVideoBackend(str(tmp_path / "wan"))
+    request = ProduceSampleRequest(
+        task_type=TaskType.TEXT_TO_VIDEO,
+        backend="wan-video",
+        model="wan2.2-t2v-A14B",
+        sample_spec=SampleSpec(prompt="stub truthfulness"),
+    )
+
+    record = await backend.produce_sample(request)
+
+    assert record.status == SampleStatus.ACCEPTED
+    assert record.runtime["runner"] == "stub"
+    assert record.metadata["stubbed"] is True
+    assert not (tmp_path / "wan" / record.sample_id / "sample.mp4").exists()
+
+    artifact_kinds = {artifact.kind for artifact in record.artifacts}
+    assert ArtifactKind.VIDEO not in artifact_kinds
+    assert {ArtifactKind.LOG, ArtifactKind.METADATA}.issubset(artifact_kinds)

--- a/wm_infra/backends/wan.py
+++ b/wm_infra/backends/wan.py
@@ -1,7 +1,7 @@
 """Wan-family video backend with async job queue and official runner support.
 
 This backend supports three execution modes:
-- **stub**: No runner configured — materializes request/log/output paths only.
+- **stub**: No runner configured — materializes request/log paths only.
 - **shell**: A shell command template is executed (WM_WAN_SHELL_RUNNER).
 - **official**: Builds and executes the real Wan2.2 generate.py command using
   the local repo path and conda env from WAN22_BASELINE.md.
@@ -331,7 +331,7 @@ class WanVideoBackend(ProduceSampleBackend):
             ],
             "started_at": started_at,
         }
-        status = SampleStatus.SUCCEEDED
+        status = SampleStatus.ACCEPTED if mode == "stub" else SampleStatus.SUCCEEDED
         metadata: dict[str, Any] = {
             "evaluation_policy": request.evaluation_policy,
             "priority": request.priority,
@@ -451,13 +451,6 @@ class WanVideoBackend(ProduceSampleBackend):
 
         artifacts = [
             self._artifact_record(
-                artifact_id=f"{sample_id}:video",
-                kind=ArtifactKind.VIDEO,
-                path=video_path,
-                mime_type="video/mp4",
-                metadata={"stubbed": mode == "stub"},
-            ),
-            self._artifact_record(
                 artifact_id=f"{sample_id}:log",
                 kind=ArtifactKind.LOG,
                 path=log_path,
@@ -478,6 +471,17 @@ class WanVideoBackend(ProduceSampleBackend):
                 metadata={"role": "runtime"},
             ),
         ]
+        if video_path.exists():
+            artifacts.insert(
+                0,
+                self._artifact_record(
+                    artifact_id=f"{sample_id}:video",
+                    kind=ArtifactKind.VIDEO,
+                    path=video_path,
+                    mime_type="video/mp4",
+                    metadata={"stubbed": mode == "stub"},
+                ),
+            )
         if failure_path.exists():
             artifacts.append(
                 self._artifact_record(

--- a/wm_infra/benchmarking.py
+++ b/wm_infra/benchmarking.py
@@ -193,6 +193,7 @@ def comparison_report(current: dict[str, Any], baseline: dict[str, Any]) -> dict
 def run_summary_from_samples(samples: list[dict[str, Any]]) -> dict[str, Any]:
     total = len(samples)
     succeeded = sum(1 for item in samples if item.get("status") == "succeeded")
+    accepted = sum(1 for item in samples if item.get("status") == "accepted")
     failed = sum(1 for item in samples if item.get("status") == "failed")
     queued = sum(1 for item in samples if item.get("status") == "queued")
     running = sum(1 for item in samples if item.get("status") == "running")
@@ -210,6 +211,7 @@ def run_summary_from_samples(samples: list[dict[str, Any]]) -> dict[str, Any]:
         "counts": {
             "total": total,
             "succeeded": succeeded,
+            "accepted": accepted,
             "failed": failed,
             "queued": queued,
             "running": running,
@@ -218,7 +220,7 @@ def run_summary_from_samples(samples: list[dict[str, Any]]) -> dict[str, Any]:
             "submit": summarize_latency_ms(submit_latencies),
             "terminal": summarize_latency_ms(terminal_latencies),
         },
-        "success_rate": (succeeded / total) if total else 0.0,
+        "success_rate": ((succeeded + accepted) / total) if total else 0.0,
     }
 
 


### PR DESCRIPTION
This PR makes Wan stub mode truthful.

What changed:
- Wan stub jobs no longer fabricate a `video` artifact when no video file exists.
- Stub jobs are recorded as `accepted` rather than `succeeded`, which makes the persisted control-plane record reflect scaffold execution instead of real video production.
- Server tests now assert the honest stub semantics and no longer expect a fake video output.

Why:
- The previous stub path could persist a success record with a video artifact even though no video had actually been produced.
- That made the control-plane state misleading for Wan video production.

Validation:
- `pytest tests/test_server.py`
- `pytest tests/test_controlplane.py`