### PR TITLE
[codex] Harden sample manifest store writes

### DIFF
--- a/tests/test_sample_store.py
+++ b/tests/test_sample_store.py
@@ -1,0 +1,62 @@
+"""Focused tests for the sample manifest store durability behavior."""
+
+from wm_infra.controlplane import ExperimentRef, SampleManifestStore, SampleRecord, SampleSpec, SampleStatus, TaskType
+
+
+def test_sample_manifest_store_put_writes_clean_final_file(tmp_path):
+    store = SampleManifestStore(tmp_path)
+    record = SampleRecord(
+        sample_id="sample_atomic",
+        task_type=TaskType.WORLD_MODEL_ROLLOUT,
+        backend="rollout-engine",
+        model="latent_dynamics",
+        status=SampleStatus.SUCCEEDED,
+        experiment=ExperimentRef(experiment_id="exp_atomic"),
+        sample_spec=SampleSpec(prompt="atomic write"),
+    )
+
+    store.put(record)
+
+    final_path = tmp_path / "samples" / "exp_atomic" / "sample_atomic.json"
+    assert final_path.exists()
+    assert store.get("sample_atomic") is not None
+    assert [path.name for path in final_path.parent.iterdir()] == ["sample_atomic.json"]
+
+
+def test_sample_manifest_store_skips_corrupt_manifest_files(tmp_path):
+    store = SampleManifestStore(tmp_path)
+    record = SampleRecord(
+        sample_id="sample_corrupt",
+        task_type=TaskType.WORLD_MODEL_ROLLOUT,
+        backend="rollout-engine",
+        model="latent_dynamics",
+        status=SampleStatus.SUCCEEDED,
+        experiment=ExperimentRef(experiment_id="exp_clean"),
+        sample_spec=SampleSpec(prompt="keep the clean record"),
+    )
+
+    store.put(record)
+
+    corrupt_legacy_path = tmp_path / "samples" / "sample_corrupt.json"
+    corrupt_legacy_path.write_text("{not valid json")
+    corrupt_other_path = tmp_path / "samples" / "other_bucket" / "broken.json"
+    corrupt_other_path.parent.mkdir(parents=True, exist_ok=True)
+    corrupt_other_path.write_text("{still not valid json")
+
+    loaded = store.get("sample_corrupt")
+    assert loaded is not None
+    assert loaded.sample_id == "sample_corrupt"
+
+    records = store.list()
+    assert len(records) == 1
+    assert records[0].sample_id == "sample_corrupt"
+
+
+def test_sample_manifest_store_returns_none_for_corrupt_only_sample(tmp_path):
+    store = SampleManifestStore(tmp_path)
+    corrupt_path = tmp_path / "samples" / "sample_missing.json"
+    corrupt_path.parent.mkdir(parents=True, exist_ok=True)
+    corrupt_path.write_text("{broken")
+
+    assert store.get("sample_missing") is None
+    assert store.list() == []

--- a/wm_infra/controlplane/storage.py
+++ b/wm_infra/controlplane/storage.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from pathlib import Path
+
+from pydantic import ValidationError
 
 from wm_infra.controlplane.schemas import SampleRecord
 
@@ -30,29 +34,64 @@ class SampleManifestStore:
     def _record_path(self, record: SampleRecord) -> Path:
         return self.samples_dir / self._experiment_bucket(record) / f"{record.sample_id}.json"
 
-    def _find_path(self, sample_id: str) -> Path | None:
+    def _candidate_paths(self, sample_id: str) -> list[Path]:
+        candidates: list[Path] = []
         legacy_path = self.samples_dir / f"{sample_id}.json"
         if legacy_path.exists():
-            return legacy_path
+            candidates.append(legacy_path)
 
         for path in sorted(self.samples_dir.glob(f"**/{sample_id}.json")):
-            return path
-        return None
+            if path not in candidates:
+                candidates.append(path)
+        return candidates
+
+    @staticmethod
+    def _atomic_write_text(path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            delete=False,
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+        )
+        tmp_path = Path(tmp.name)
+        try:
+            with tmp:
+                tmp.write(content)
+                tmp.flush()
+                os.fsync(tmp.fileno())
+            os.replace(tmp_path, path)
+        except Exception:
+            try:
+                tmp_path.unlink()
+            except FileNotFoundError:
+                pass
+            raise
+
+    def _load_record(self, path: Path) -> SampleRecord | None:
+        try:
+            return SampleRecord.model_validate_json(path.read_text())
+        except (FileNotFoundError, json.JSONDecodeError, ValidationError):
+            return None
 
     def put(self, record: SampleRecord) -> SampleRecord:
         path = self._record_path(record)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(record.model_dump(mode="json"), indent=2, sort_keys=True))
+        self._atomic_write_text(path, json.dumps(record.model_dump(mode="json"), indent=2, sort_keys=True))
         return record
 
     def get(self, sample_id: str) -> SampleRecord | None:
-        path = self._find_path(sample_id)
-        if path is None:
-            return None
-        return SampleRecord.model_validate_json(path.read_text())
+        for path in self._candidate_paths(sample_id):
+            record = self._load_record(path)
+            if record is not None:
+                return record
+        return None
 
     def list(self) -> list[SampleRecord]:
         records = []
         for path in sorted(self.samples_dir.glob("**/*.json")):
-            records.append(SampleRecord.model_validate_json(path.read_text()))
+            record = self._load_record(path)
+            if record is not None:
+                records.append(record)
         return records


### PR DESCRIPTION
This PR hardens the file-backed sample manifest store.

What changed:
- Sample manifests are now written atomically through a temporary file + `os.replace` path.
- `get()` and `list()` skip corrupt JSON/validation failures instead of crashing the whole store.
- Focused store tests verify atomic final-file behavior and corrupt-file tolerance.

Why:
- The previous store wrote directly to the final path and trusted every JSON file it found.
- That made sample persistence fragile under interruption or partial corruption.

Validation:
- `pytest tests/test_sample_store.py`
- `pytest tests/test_controlplane.py`