### PR TITLE
[codex] Add API guardrails and sample metrics

### DIFF
--- a/tests/test_api_guardrails.py
+++ b/tests/test_api_guardrails.py
@@ -1,0 +1,168 @@
+"""Tests for northbound auth, sample metrics, and strict request contracts."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from wm_infra.api.server import create_app
+from wm_infra.config import ControlPlaneConfig, DynamicsConfig, EngineConfig, ServerConfig, StateCacheConfig, TokenizerConfig
+from wm_infra.controlplane import SampleManifestStore
+
+
+def _guarded_config() -> EngineConfig:
+    return EngineConfig(
+        device="cpu",
+        dtype="float32",
+        dynamics=DynamicsConfig(
+            hidden_dim=64,
+            num_heads=4,
+            num_layers=2,
+            action_dim=8,
+            latent_token_dim=6,
+            max_rollout_steps=16,
+        ),
+        tokenizer=TokenizerConfig(
+            spatial_downsample=2,
+            temporal_downsample=1,
+            latent_channels=16,
+            fsq_levels=[4, 4, 4, 3, 3, 3],
+        ),
+        state_cache=StateCacheConfig(
+            max_batch_size=8,
+            max_rollout_steps=16,
+            latent_dim=6,
+            num_latent_tokens=16,
+            pool_size_gb=0.1,
+        ),
+        server=ServerConfig(api_key="test-secret"),
+        controlplane=ControlPlaneConfig(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_api_key_guard_protects_sample_and_queue_endpoints(tmp_path):
+    from asgi_lifespan import LifespanManager
+
+    config = _guarded_config()
+    app = create_app(config, sample_store=SampleManifestStore(tmp_path))
+
+    async with LifespanManager(app) as manager:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=manager.app),
+            base_url="http://test",
+        ) as client:
+            health_resp = await client.get("/v1/health")
+            assert health_resp.status_code == 200
+
+            denied = await client.post("/v1/samples", json={
+                "task_type": "world_model_rollout",
+                "backend": "rollout-engine",
+                "model": "latent_dynamics",
+                "sample_spec": {"prompt": "guarded"},
+                "return_artifacts": ["latent"],
+            })
+            assert denied.status_code == 401
+
+            auth_metrics = await client.get("/metrics")
+            assert auth_metrics.status_code == 200
+            assert 'wm_api_auth_failures_total{endpoint="/v1/samples"} 1.0' in auth_metrics.text
+
+            allowed = await client.post(
+                "/v1/samples",
+                headers={"X-API-Key": "test-secret"},
+                json={
+                    "task_type": "world_model_rollout",
+                    "backend": "rollout-engine",
+                    "model": "latent_dynamics",
+                    "sample_spec": {"prompt": "guarded"},
+                    "return_artifacts": ["latent"],
+                },
+            )
+            assert allowed.status_code == 200
+            assert allowed.json()["status"] == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_strict_contract_ignores_legacy_metadata(tmp_path):
+    from asgi_lifespan import LifespanManager
+
+    config = EngineConfig(
+        device="cpu",
+        dtype="float32",
+        dynamics=DynamicsConfig(
+            hidden_dim=64,
+            num_heads=4,
+            num_layers=2,
+            action_dim=8,
+            latent_token_dim=6,
+            max_rollout_steps=16,
+        ),
+        tokenizer=TokenizerConfig(
+            spatial_downsample=2,
+            temporal_downsample=1,
+            latent_channels=16,
+            fsq_levels=[4, 4, 4, 3, 3, 3],
+        ),
+        state_cache=StateCacheConfig(
+            max_batch_size=8,
+            max_rollout_steps=16,
+            latent_dim=6,
+            num_latent_tokens=16,
+            pool_size_gb=0.1,
+        ),
+        controlplane=ControlPlaneConfig(),
+    )
+    app = create_app(config, sample_store=SampleManifestStore(tmp_path))
+
+    async with LifespanManager(app) as manager:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=manager.app),
+            base_url="http://test",
+        ) as client:
+            resp = await client.post("/v1/samples", json={
+                "task_type": "world_model_rollout",
+                "backend": "rollout-engine",
+                "model": "latent_dynamics",
+                "contract_mode": "strict",
+                "sample_spec": {
+                    "prompt": "strict mode",
+                    "metadata": {"num_steps": 3, "episode_id": "episode-legacy"},
+                },
+                "return_artifacts": ["latent"],
+            })
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["task_config"]["num_steps"] == 1
+            assert data["temporal"] is None
+            assert data["runtime"]["steps_completed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_sample_metrics_are_exposed(tmp_path):
+    from asgi_lifespan import LifespanManager
+
+    config = _guarded_config()
+    config.server.api_key = None
+    app = create_app(config, sample_store=SampleManifestStore(tmp_path))
+
+    async with LifespanManager(app) as manager:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=manager.app),
+            base_url="http://test",
+        ) as client:
+            resp = await client.post("/v1/samples", json={
+                "task_type": "world_model_rollout",
+                "backend": "rollout-engine",
+                "model": "latent_dynamics",
+                "sample_spec": {"prompt": "metrics"},
+                "return_artifacts": ["latent"],
+            })
+            assert resp.status_code == 200
+
+            await client.get("/v1/queue/status")
+            metrics = await client.get("/metrics")
+            assert metrics.status_code == 200
+            assert 'wm_sample_total{backend="rollout-engine",status="succeeded"}' in metrics.text
+            assert 'wm_sample_duration_seconds_count{backend="rollout-engine",status="succeeded"}' in metrics.text
+            assert "wm_queue_depth" in metrics.text

--- a/wm_infra/api/metrics.py
+++ b/wm_infra/api/metrics.py
@@ -22,6 +22,25 @@ REQUEST_DURATION = Histogram(
     buckets=[0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0],
 )
 
+API_AUTH_FAILURES = Counter(
+    "wm_api_auth_failures_total",
+    "API authentication failures",
+    ["endpoint"],
+)
+
+SAMPLE_TOTAL = Counter(
+    "wm_sample_total",
+    "Total sample-production requests",
+    ["backend", "status"],
+)
+
+SAMPLE_DURATION = Histogram(
+    "wm_sample_duration_seconds",
+    "End-to-end sample-production request duration",
+    ["backend", "status"],
+    buckets=[0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0],
+)
+
 # ─── Engine-level metrics ───
 
 BATCH_SIZE = Histogram(

--- a/wm_infra/api/server.py
+++ b/wm_infra/api/server.py
@@ -35,7 +35,7 @@ from urllib.parse import unquote
 import numpy as np
 import torch
 
-from wm_infra.api.metrics import REQUEST_DURATION, REQUEST_TOTAL
+from wm_infra.api.metrics import ACTIVE_ROLLOUTS, API_AUTH_FAILURES, QUEUE_DEPTH, REQUEST_DURATION, REQUEST_TOTAL, SAMPLE_DURATION, SAMPLE_TOTAL
 from wm_infra.api.protocol import HealthResponse, RolloutRequest, RolloutResponse, SSE_DONE, StepResult
 from wm_infra.backends import BackendRegistry, GenieJobQueue, GenieRolloutBackend, RolloutBackend, WanJobQueue, WanVideoBackend
 from wm_infra.backends.genie_runner import GenieRunner
@@ -116,7 +116,7 @@ def create_app(
     temporal_store: Optional[TemporalStore] = None,
 ):
     from fastapi import FastAPI, HTTPException
-    from fastapi.responses import StreamingResponse
+    from fastapi.responses import JSONResponse, StreamingResponse
 
     if config is None:
         config = EngineConfig()
@@ -213,9 +213,31 @@ def create_app(
 
     app = FastAPI(title="wm-infra", description="Temporal model serving and control-plane infrastructure", version="0.1.0", lifespan=lifespan)
 
+    @app.middleware("http")
+    async def api_key_guard(request, call_next):
+        api_key = config.server.api_key
+        if api_key is None:
+            return await call_next(request)
+
+        path = request.url.path
+        if (
+            path in {"/v1/health", "/v1/models", "/metrics", "/openapi.json"}
+            or path.startswith("/docs")
+            or path.startswith("/redoc")
+            or request.method in {"OPTIONS", "HEAD"}
+        ):
+            return await call_next(request)
+
+        provided = request.headers.get("X-API-Key")
+        if provided != api_key:
+            API_AUTH_FAILURES.labels(endpoint=path).inc()
+            return JSONResponse(status_code=401, content={"detail": "Invalid or missing API key"})
+        return await call_next(request)
+
     @app.get("/v1/health", response_model=HealthResponse)
     async def health():
         ready = _engine is not None and _engine.is_running
+        ACTIVE_ROLLOUTS.set(_engine.engine.state_manager.num_active if _engine else 0)
         return HealthResponse(
             status="ready" if ready else "not_ready",
             model_loaded=_engine is not None,
@@ -330,6 +352,10 @@ def create_app(
 
     @app.post("/v1/samples")
     async def produce_sample(request: ProduceSampleRequest):
+        import time as _time
+
+        sample_t0 = _time.monotonic()
+        sample_status = "error"
         registry: BackendRegistry = app.state.backend_registry
         store: SampleManifestStore = app.state.sample_store
 
@@ -337,25 +363,33 @@ def create_app(
         if backend is None:
             raise HTTPException(status_code=404, detail=f"Unknown backend: {request.backend}")
 
-        if (isinstance(backend, WanVideoBackend) and backend._job_queue is not None) or (
-            isinstance(backend, GenieRolloutBackend) and backend._job_queue is not None
-        ):
-            try:
-                record = backend.submit_async(request)
-            except ValueError as exc:
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
-            except RuntimeError as exc:
-                raise HTTPException(status_code=503, detail=str(exc)) from exc
-            store.put(record)
-            return record.model_dump(mode="json")
-
         try:
-            record = await backend.produce_sample(request)
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+            if (isinstance(backend, WanVideoBackend) and backend._job_queue is not None) or (
+                isinstance(backend, GenieRolloutBackend) and backend._job_queue is not None
+            ):
+                try:
+                    record = backend.submit_async(request)
+                except ValueError as exc:
+                    SAMPLE_TOTAL.labels(backend=request.backend, status="error").inc()
+                    raise HTTPException(status_code=400, detail=str(exc)) from exc
+                except RuntimeError as exc:
+                    SAMPLE_TOTAL.labels(backend=request.backend, status="error").inc()
+                    raise HTTPException(status_code=503, detail=str(exc)) from exc
+                store.put(record)
+                SAMPLE_TOTAL.labels(backend=request.backend, status=record.status.value).inc()
+                sample_status = record.status.value
+                return record.model_dump(mode="json")
 
-        store.put(record)
-        return record.model_dump(mode="json")
+            record = await backend.produce_sample(request)
+            store.put(record)
+            SAMPLE_TOTAL.labels(backend=request.backend, status=record.status.value).inc()
+            sample_status = record.status.value
+            return record.model_dump(mode="json")
+        except ValueError as exc:
+            SAMPLE_TOTAL.labels(backend=request.backend, status="error").inc()
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        finally:
+            SAMPLE_DURATION.labels(backend=request.backend, status=sample_status).observe(_time.monotonic() - sample_t0)
 
     @app.get("/v1/samples")
     async def list_samples(status: str | None = None, backend: str | None = None, experiment_id: str | None = None, limit: int = 50):
@@ -426,11 +460,15 @@ def create_app(
         wan_queue = app.state.wan_job_queue
         genie_queue = app.state.genie_job_queue
         if wan_queue is None and genie_queue is None:
+            QUEUE_DEPTH.set(0)
             return {"queue_enabled": False}
+        pending = (wan_queue.pending_count if wan_queue else 0) + (genie_queue.pending_count if genie_queue else 0)
+        running = (wan_queue.running_count if wan_queue else 0) + (genie_queue.running_count if genie_queue else 0)
+        QUEUE_DEPTH.set(pending)
         return {
             "queue_enabled": True,
-            "pending": (wan_queue.pending_count if wan_queue else 0) + (genie_queue.pending_count if genie_queue else 0),
-            "running": (wan_queue.running_count if wan_queue else 0) + (genie_queue.running_count if genie_queue else 0),
+            "pending": pending,
+            "running": running,
             "total_tracked": (wan_queue.total_count if wan_queue else 0) + (genie_queue.total_count if genie_queue else 0),
             "queues": {
                 "wan": None if wan_queue is None else wan_queue.snapshot(),

--- a/wm_infra/config.py
+++ b/wm_infra/config.py
@@ -84,6 +84,7 @@ class ServerConfig:
     port: int = 8400
     max_concurrent_requests: int = 128
     stream_chunk_interval_ms: float = 33.0  # ~30fps streaming
+    api_key: Optional[str] = None
 
 
 @dataclass
@@ -161,6 +162,7 @@ def _env_overrides() -> dict:
         WM_MODEL_PATH=/path            → {"model_path": "/path"}
         WM_PORT=9000                   → {"server": {"port": 9000}}
         WM_HOST=127.0.0.1              → {"server": {"host": "127.0.0.1"}}
+        WM_API_KEY=secret              → {"server": {"api_key": "secret"}}
         WM_MAX_BATCH_SIZE=16           → {"scheduler": {"max_batch_size": 16}}
         WM_MANIFEST_STORE_ROOT=/data   → {"controlplane": {"manifest_store_root": "/data"}}
         WM_WAN_OUTPUT_ROOT=/data/wan   → {"controlplane": {"wan_output_root": "/data/wan"}}
@@ -183,6 +185,7 @@ def _env_overrides() -> dict:
         "WM_SEED": (["seed"], int),
         "WM_PORT": (["server", "port"], int),
         "WM_HOST": (["server", "host"], str),
+        "WM_API_KEY": (["server", "api_key"], str),
         "WM_MAX_BATCH_SIZE": (["scheduler", "max_batch_size"], int),
         "WM_MAX_CONCURRENT_ROLLOUTS": (["scheduler", "max_concurrent_rollouts"], int),
         "WM_MANIFEST_STORE_ROOT": (["controlplane", "manifest_store_root"], str),
@@ -257,6 +260,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--dtype", type=str, choices=["float16", "float32", "bfloat16"], default=None)
     parser.add_argument("--port", type=int, default=None, help="Server port (default: 8400)")
     parser.add_argument("--host", type=str, default=None, help="Server host (default: 0.0.0.0)")
+    parser.add_argument("--api-key", type=str, default=None, help="Optional API key required for protected endpoints")
     parser.add_argument("--max-batch-size", type=int, default=None, help="Max batch size for scheduling")
     parser.add_argument("--seed", type=int, default=None)
     return parser
@@ -305,6 +309,8 @@ def load_config(
         cli_overrides.setdefault("server", {})["port"] = args.port
     if args.host is not None:
         cli_overrides.setdefault("server", {})["host"] = args.host
+    if args.api_key is not None:
+        cli_overrides.setdefault("server", {})["api_key"] = args.api_key
     if args.max_batch_size is not None:
         cli_overrides.setdefault("scheduler", {})["max_batch_size"] = args.max_batch_size
 

--- a/wm_infra/controlplane/schemas.py
+++ b/wm_infra/controlplane/schemas.py
@@ -209,6 +209,7 @@ class ProduceSampleRequest(BaseModel):
     backend: str = Field(..., description="Backend/runtime identifier")
     model: str = Field(..., description="Logical model identifier")
     model_revision: Optional[str] = None
+    contract_mode: Literal["legacy", "strict"] = "legacy"
     experiment: Optional[ExperimentRef] = None
     sample_spec: SampleSpec
     temporal: Optional[TemporalRefs] = None
@@ -251,34 +252,35 @@ class ProduceSampleRequest(BaseModel):
         task_config = self.task_config or RolloutTaskConfig()
         used_legacy_metadata = False
 
-        if self.task_type in {TaskType.WORLD_MODEL_ROLLOUT, TaskType.GENIE_ROLLOUT}:
-            if task_config.num_steps == 1 and metadata.get("num_steps") is not None:
-                task_config.num_steps = int(metadata["num_steps"])
-                used_legacy_metadata = True
+        if self.contract_mode == "legacy":
+            if self.task_type in {TaskType.WORLD_MODEL_ROLLOUT, TaskType.GENIE_ROLLOUT}:
+                if task_config.num_steps == 1 and metadata.get("num_steps") is not None:
+                    task_config.num_steps = int(metadata["num_steps"])
+                    used_legacy_metadata = True
 
-        legacy_map = {
-            "frame_count": ("frame_count", int),
-            "frame_num": ("frame_count", int),
-            "sample_steps": ("num_steps", int),
-            "width": ("width", int),
-            "height": ("height", int),
-            "offload_model": ("offload_model", bool),
-            "convert_model_dtype": ("convert_model_dtype", bool),
-            "t5_cpu": ("t5_cpu", bool),
-            "memory_profile": ("memory_profile", VideoMemoryProfile),
-        }
-        for legacy_key, (field_name, coercer) in legacy_map.items():
-            current = getattr(task_config, field_name)
-            if current is None and metadata.get(legacy_key) is not None:
-                value = metadata[legacy_key]
-                if coercer is bool and isinstance(value, str):
-                    value = value.lower() in {"1", "true", "yes", "on"}
-                elif coercer is VideoMemoryProfile:
-                    value = VideoMemoryProfile(value)
-                else:
-                    value = coercer(value)
-                setattr(task_config, field_name, value)
-                used_legacy_metadata = True
+            legacy_map = {
+                "frame_count": ("frame_count", int),
+                "frame_num": ("frame_count", int),
+                "sample_steps": ("num_steps", int),
+                "width": ("width", int),
+                "height": ("height", int),
+                "offload_model": ("offload_model", bool),
+                "convert_model_dtype": ("convert_model_dtype", bool),
+                "t5_cpu": ("t5_cpu", bool),
+                "memory_profile": ("memory_profile", VideoMemoryProfile),
+            }
+            for legacy_key, (field_name, coercer) in legacy_map.items():
+                current = getattr(task_config, field_name)
+                if current is None and metadata.get(legacy_key) is not None:
+                    value = metadata[legacy_key]
+                    if coercer is bool and isinstance(value, str):
+                        value = value.lower() in {"1", "true", "yes", "on"}
+                    elif coercer is VideoMemoryProfile:
+                        value = VideoMemoryProfile(value)
+                    else:
+                        value = coercer(value)
+                    setattr(task_config, field_name, value)
+                    used_legacy_metadata = True
 
         if task_config.width is None and self.sample_spec.width is not None:
             task_config.width = self.sample_spec.width
@@ -289,7 +291,7 @@ class ProduceSampleRequest(BaseModel):
             self.task_config = task_config
 
         wan_types = {TaskType.TEXT_TO_VIDEO, TaskType.IMAGE_TO_VIDEO}
-        if self.task_type in wan_types and self.wan_config is None:
+        if self.contract_mode == "legacy" and self.task_type in wan_types and self.wan_config is None:
             wan_meta_keys = {"guidance_scale", "shift", "model_size", "ckpt_dir"}
             if metadata.keys() & wan_meta_keys:
                 wan_kwargs: dict[str, Any] = {}
@@ -311,17 +313,18 @@ class ProduceSampleRequest(BaseModel):
                     wan_kwargs.setdefault("memory_profile", task_config.memory_profile)
                 self.wan_config = WanTaskConfig(**wan_kwargs)
 
-        if self.temporal is None and any(metadata.get(k) for k in ("episode_id", "rollout_id", "branch_id", "checkpoint_id", "state_handle_id")):
-            self.temporal = TemporalRefs(
-                episode_id=metadata.get("episode_id"),
-                rollout_id=metadata.get("rollout_id"),
-                branch_id=metadata.get("branch_id"),
-                checkpoint_id=metadata.get("checkpoint_id"),
-                state_handle_id=metadata.get("state_handle_id"),
-                parent_state_handle_id=metadata.get("parent_state_handle_id"),
-            )
+        if self.contract_mode == "legacy":
+            if self.temporal is None and any(metadata.get(k) for k in ("episode_id", "rollout_id", "branch_id", "checkpoint_id", "state_handle_id")):
+                self.temporal = TemporalRefs(
+                    episode_id=metadata.get("episode_id"),
+                    rollout_id=metadata.get("rollout_id"),
+                    branch_id=metadata.get("branch_id"),
+                    checkpoint_id=metadata.get("checkpoint_id"),
+                    state_handle_id=metadata.get("state_handle_id"),
+                    parent_state_handle_id=metadata.get("parent_state_handle_id"),
+                )
 
-        if self.token_input is None:
+        if self.contract_mode == "legacy" and self.token_input is None:
             token_input_meta = metadata.get("token_input")
             if isinstance(token_input_meta, dict):
                 self.token_input = TokenInputSpec(**token_input_meta)


### PR DESCRIPTION
This PR adds a minimum northbound hardening slice for wm-infra.

What changed:
- Added optional API-key protection for protected HTTP paths via config/env so the sample-production and rollout surfaces are not necessarily unauthenticated.
- Added sample/backend/auth metrics so observability is no longer rollout-only.
- Added a strict contract mode that disables legacy metadata backfill for production-like callers, while keeping compatibility as an opt-in/opt-out choice.
- Added focused tests for auth behavior, contract strictness, and metric surfacing.

Why:
- The repo had no auth or request guardrail path on the public-facing API surface.
- Metrics were heavily rollout-centric and did not cover sample-production behavior.
- Legacy metadata backfill remained the only request-contract path unless callers happened to use first-class config correctly.

Validation:
- `pytest tests/test_api_guardrails.py tests/test_server.py tests/test_controlplane.py`