### PR TITLE
[codex] Refactor RL API toward stateless transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,18 @@ This is still available:
 
 Useful for engine work, but not the primary framing for the repo.
 
+### Stateless transition API
+For trainer-style world-model stepping, prefer explicit state references over
+server-owned sessions.
+
+- `POST /v1/transitions/initialize`
+- `POST /v1/transitions/predict`
+- `POST /v1/transitions/predict_many`
+
+These routes return durable resource IDs such as `state_handle_id`,
+`trajectory_id`, `branch_id`, and `episode_id`. Callers continue work by
+submitting those IDs explicitly rather than relying on an in-memory session.
+
 ## Repo layout
 
 ```text

--- a/docs/RL_ENV_USAGE.md
+++ b/docs/RL_ENV_USAGE.md
@@ -4,14 +4,16 @@
 module does not turn the repository into a full RL platform yet. What it does give
 you today is both:
 
-- a northbound environment-session API at `/v1/envs`
+- a stateless transition API at `/v1/transitions/initialize` and `/v1/transitions/predict(_many)`
 - a local trainer-facing experiment surface on top of the same contract
 
 This is the right current split:
 
 - `POST /v1/samples` remains the product-facing API for persisted sample production.
+- `POST /v1/transitions/initialize`, `/predict`, and `/predict_many`
+  are the preferred trainer-facing stateless surface for RL state progression.
 - `POST /v1/envs`, `/reset`, `/step`, `/step_many`, `/fork`, and `/checkpoint`
-  are the trainer-facing control-plane surface for RL sessions.
+  remain as a deprecated compatibility layer for older session-oriented clients.
 - `wm_infra.rl` provides local experiment primitives that exercise the same env,
   trajectory, replay, and evaluation semantics without requiring an external trainer.
 
@@ -65,7 +67,7 @@ The current RL module contains:
 - `WorldModelVectorEnv`: vectorized batched adapter
 - `ToyLineWorldModel`: a deterministic 1D toy world model for stable examples
 - `GenieWorldModelAdapter`: action-conditioned Genie token-history adapter
-- `RLEnvironmentManager`: northbound environment/session runtime for `/v1/envs`
+- `RLEnvironmentManager`: trainer runtime for both stateless transition routes and legacy `/v1/envs`
 - `ExperimentSpec`: declarative local experiment configuration
 - `SynchronousCollector`: batched rollout collector backed by env sessions
 - `LocalActorCriticLearner`: minimal learner adapter
@@ -85,10 +87,20 @@ Relevant files:
 
 ## Northbound RL API
 
-The trainer-facing HTTP surface now exists.
+The preferred trainer-facing HTTP surface is explicit and stateless.
 
 - `GET /v1/env-specs`
 - `GET /v1/task-specs`
+- `POST /v1/transitions/initialize`
+- `POST /v1/transitions/predict`
+- `POST /v1/transitions/predict_many`
+- `GET /v1/transitions`
+- `GET /v1/trajectories`
+- `GET /v1/evaluations`
+
+The legacy session-oriented compatibility surface still exists, but it should
+not be the default for new integrations:
+
 - `POST /v1/envs`
 - `GET /v1/envs`
 - `GET /v1/envs/{env_id}`
@@ -98,9 +110,6 @@ The trainer-facing HTTP surface now exists.
 - `POST /v1/envs/{env_id}/fork`
 - `POST /v1/envs/{env_id}/checkpoint`
 - `DELETE /v1/envs/{env_id}`
-- `GET /v1/transitions`
-- `GET /v1/trajectories`
-- `GET /v1/evaluations`
 
 The current toy env registry ships with:
 
@@ -124,23 +133,38 @@ That keeps the contract runnable and benchmarkable without pretending CPU has a
 stable real Genie execution path. On CUDA-capable machines, the adapter can
 attempt real Genie execution.
 
-Every step response carries the stable RL fields the trainer actually needs:
+Every transition response carries the stable RL fields the trainer actually needs:
 
 - `observation`
 - `reward`
 - `terminated`
 - `truncated`
 - `info`
-- `env_id`
 - `episode_id`
 - `task_id`
 - `state_handle_id`
 - `checkpoint_id`
 - `policy_version`
 
-The `step_many` route is not just a list of independent HTTP calls. It executes a
-single batched `predict_next()` over all selected sessions and persists the resulting
-`TransitionRecord` objects into the temporal control plane.
+The stateless `predict_many` route is not just a list of independent HTTP calls.
+It executes a single batched `predict_next()` over all selected state handles and
+persists the resulting `TransitionRecord` objects into the temporal control plane.
+
+## Stateless Usage
+
+The preferred HTTP flow is:
+
+1. call `POST /v1/transitions/initialize`
+2. keep the returned `state_handle_id` and `trajectory_id`
+3. submit the next action through `POST /v1/transitions/predict`
+4. for batched stepping, submit several `(state_handle_id, action, trajectory_id)`
+   items to `POST /v1/transitions/predict_many`
+
+This keeps the northbound API stateless:
+
+- the server does not need an in-memory env session to continue the rollout
+- callers move forward by explicitly providing resource IDs
+- restarting the service does not invalidate the contract
 
 ## Single-Environment Usage
 

--- a/tests/test_rl_api.py
+++ b/tests/test_rl_api.py
@@ -94,12 +94,97 @@ async def test_rl_catalog_endpoints_expose_default_env_and_tasks(client):
 
 
 @pytest.mark.asyncio
+async def test_stateless_initialize_and_predict_transition(client):
+    init_resp = await client.post(
+        "/v1/transitions/initialize",
+        json={"env_name": "toy-line-v0", "task_id": "toy-line-eval", "seed": 7, "policy_version": "pi-1"},
+    )
+    assert init_resp.status_code == 200
+    initialized = init_resp.json()
+    assert initialized["current_step"] == 0
+    assert initialized["trajectory_id"] is not None
+    assert initialized["state_handle_id"] is not None
+
+    step_resp = await client.post(
+        "/v1/transitions/predict",
+        json={
+            "state_handle_id": initialized["state_handle_id"],
+            "trajectory_id": initialized["trajectory_id"],
+            "action": [0.0, 0.0, 1.0],
+            "policy_version": "pi-1",
+        },
+    )
+    assert step_resp.status_code == 200
+    stepped = step_resp.json()
+    assert stepped["step_idx"] == 1
+    assert stepped["reward"] == pytest.approx(-0.16)
+    assert stepped["terminated"] is False
+    assert stepped["truncated"] is False
+    assert stepped["trajectory_id"] == initialized["trajectory_id"]
+    assert stepped["state_handle_id"] != initialized["state_handle_id"]
+
+    transitions_resp = await client.get("/v1/transitions", params={"trajectory_id": initialized["trajectory_id"]})
+    assert transitions_resp.status_code == 200
+    transitions = transitions_resp.json()["transitions"]
+    assert len(transitions) == 1
+    assert transitions[0]["reward"] == pytest.approx(-0.16)
+
+    trajectories_resp = await client.get("/v1/trajectories", params={"episode_id": initialized["episode_id"]})
+    assert trajectories_resp.status_code == 200
+    trajectories = trajectories_resp.json()["trajectories"]
+    assert len(trajectories) == 1
+    assert trajectories[0]["num_steps"] == 1
+    assert trajectories[0]["return_value"] == pytest.approx(-0.16)
+
+
+@pytest.mark.asyncio
+async def test_stateless_predict_many_batches_explicit_state_handles(client):
+    init_responses = []
+    for seed in (3, 9):
+        resp = await client.post(
+            "/v1/transitions/initialize",
+            json={"env_name": "toy-line-v0", "task_id": "toy-line-eval", "seed": seed},
+        )
+        assert resp.status_code == 200
+        init_responses.append(resp.json())
+
+    step_many_resp = await client.post(
+        "/v1/transitions/predict_many",
+        json={
+            "items": [
+                {
+                    "state_handle_id": init_responses[0]["state_handle_id"],
+                    "trajectory_id": init_responses[0]["trajectory_id"],
+                    "action": [0.0, 0.0, 1.0],
+                },
+                {
+                    "state_handle_id": init_responses[1]["state_handle_id"],
+                    "trajectory_id": init_responses[1]["trajectory_id"],
+                    "action": [1.0, 0.0, 0.0],
+                },
+            ],
+            "policy_version": "pi-batch",
+            "checkpoint": True,
+        },
+    )
+    assert step_many_resp.status_code == 200
+    payload = step_many_resp.json()
+    assert len(payload["results"]) == 2
+    assert payload["runtime"]["execution_path"] == "chunked_stateless_transition"
+    assert payload["runtime"]["chunk_count"] >= 1
+    assert payload["runtime"]["max_chunk_size"] >= 2
+    assert all(item["step_idx"] == 1 for item in payload["results"])
+    assert all(item["checkpoint_id"] is not None for item in payload["results"])
+
+
+@pytest.mark.asyncio
 async def test_create_step_and_persist_transition_and_trajectory(client):
     create_resp = await client.post(
         "/v1/envs",
         json={"env_name": "toy-line-v0", "task_id": "toy-line-eval", "seed": 7, "policy_version": "pi-1"},
     )
     assert create_resp.status_code == 200
+    assert create_resp.headers["Deprecation"] == "true"
     created = create_resp.json()
     assert created["current_step"] == 0
     assert created["task_id"] == "toy-line-eval"

--- a/tests/test_rl_runtime.py
+++ b/tests/test_rl_runtime.py
@@ -40,6 +40,44 @@ def test_step_many_splits_into_multiple_chunks_when_batch_exceeds_limit(tmp_path
     assert response.runtime["trajectory_persist_ms"] >= 0.0
 
 
+def test_stateless_predict_many_splits_into_multiple_chunks_when_batch_exceeds_limit(tmp_path) -> None:
+    manager = RLEnvironmentManager(TemporalStore(tmp_path / "temporal"), max_chunk_size=2)
+    contexts = [
+        manager.initialize_transition_context(
+            env_name="toy-line-v0",
+            task_id="toy-line-eval",
+            seed=10 + index,
+            policy_version="pi-stateless",
+            max_episode_steps=4,
+            branch_name=None,
+            labels={},
+            metadata={},
+        )
+        for index in range(5)
+    ]
+
+    response = manager.predict_many_transitions(
+        items=[
+            {
+                "state_handle_id": context.state_handle_id,
+                "trajectory_id": context.trajectory_id,
+                "action": [0.0, 0.0, 1.0],
+            }
+            for context in contexts
+        ],
+        policy_version="pi-stateless",
+        checkpoint=False,
+        metadata={},
+    )
+
+    assert len(response.results) == 5
+    assert response.runtime["chunk_count"] == 3
+    assert response.runtime["chunk_sizes"] == [2, 2, 1]
+    assert response.runtime["max_chunk_size"] == 2
+    assert response.runtime["reward_stage_ms"] >= 0.0
+    assert response.runtime["trajectory_persist_ms"] >= 0.0
+
+
 def test_genie_env_step_many_uses_genie_action_contract(tmp_path) -> None:
     manager = RLEnvironmentManager(TemporalStore(tmp_path / "temporal"), max_chunk_size=2)
     sessions = [
@@ -67,6 +105,43 @@ def test_genie_env_step_many_uses_genie_action_contract(tmp_path) -> None:
     finally:
         for session in sessions:
             manager.delete_session(session.env_id)
+
+    assert len(response.results) == 3
+    assert response.runtime["chunk_count"] == 2
+    assert response.runtime["chunk_sizes"] == [2, 1]
+    assert all("token_l1" in item.info for item in response.results)
+    assert all(len(item.observation) == manager.genie_world_model.spec.state_token_count for item in response.results)
+
+
+def test_stateless_genie_predict_many_uses_genie_action_contract(tmp_path) -> None:
+    manager = RLEnvironmentManager(TemporalStore(tmp_path / "temporal"), max_chunk_size=2)
+    contexts = [
+        manager.initialize_transition_context(
+            env_name="genie-token-grid-v0",
+            task_id="genie-token-eval",
+            seed=20 + index,
+            policy_version="pi-genie",
+            max_episode_steps=3,
+            branch_name=None,
+            labels={},
+            metadata={},
+        )
+        for index in range(3)
+    ]
+
+    response = manager.predict_many_transitions(
+        items=[
+            {
+                "state_handle_id": context.state_handle_id,
+                "trajectory_id": context.trajectory_id,
+                "action": [1.0, 0.0, 0.0, 0.0, 0.0],
+            }
+            for context in contexts
+        ],
+        policy_version="pi-genie",
+        checkpoint=False,
+        metadata={},
+    )
 
     assert len(response.results) == 3
     assert response.runtime["chunk_count"] == 2

--- a/wm_infra/api/protocol.py
+++ b/wm_infra/api/protocol.py
@@ -164,3 +164,77 @@ class EnvironmentStepManyResponse(BaseModel):
     env_ids: list[str]
     results: list[EnvironmentStepResponse]
     runtime: dict[str, Any] = Field(default_factory=dict)
+
+
+class TransitionInitializeRequest(BaseModel):
+    env_name: str
+    task_id: Optional[str] = None
+    seed: Optional[int] = None
+    policy_version: Optional[str] = None
+    max_episode_steps: Optional[int] = Field(default=None, ge=1)
+    branch_name: Optional[str] = None
+    labels: dict[str, str] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class TransitionContextResponse(BaseModel):
+    env_name: str
+    episode_id: str
+    task_id: str
+    branch_id: str
+    state_handle_id: str
+    checkpoint_id: Optional[str] = None
+    trajectory_id: str
+    current_step: int = 0
+    policy_version: Optional[str] = None
+    max_episode_steps: int
+    observation: list[list[float]] = Field(default_factory=list)
+    info: dict[str, Any] = Field(default_factory=dict)
+
+
+class TransitionPredictRequest(BaseModel):
+    state_handle_id: str
+    action: list[float]
+    trajectory_id: Optional[str] = None
+    policy_version: Optional[str] = None
+    checkpoint: bool = False
+    max_episode_steps: Optional[int] = Field(default=None, ge=1)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class TransitionPredictItem(BaseModel):
+    state_handle_id: str
+    action: list[float]
+    trajectory_id: Optional[str] = None
+    max_episode_steps: Optional[int] = Field(default=None, ge=1)
+
+
+class TransitionPredictResponse(BaseModel):
+    env_name: str
+    episode_id: str
+    task_id: str
+    branch_id: Optional[str] = None
+    trajectory_id: str
+    state_handle_id: str
+    checkpoint_id: Optional[str] = None
+    transition_id: str
+    policy_version: Optional[str] = None
+    step_idx: int
+    max_episode_steps: int
+    observation: list[list[float]]
+    reward: float
+    terminated: bool
+    truncated: bool
+    info: dict[str, Any] = Field(default_factory=dict)
+
+
+class TransitionPredictManyRequest(BaseModel):
+    items: list[TransitionPredictItem] = Field(default_factory=list)
+    policy_version: Optional[str] = None
+    checkpoint: bool = False
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class TransitionPredictManyResponse(BaseModel):
+    results: list[TransitionPredictResponse] = Field(default_factory=list)
+    runtime: dict[str, Any] = Field(default_factory=dict)

--- a/wm_infra/api/server.py
+++ b/wm_infra/api/server.py
@@ -34,6 +34,7 @@ from urllib.parse import unquote
 
 import numpy as np
 import torch
+from fastapi import Response
 
 from wm_infra.api.metrics import ACTIVE_ROLLOUTS, API_AUTH_FAILURES, QUEUE_DEPTH, REQUEST_DURATION, REQUEST_TOTAL, SAMPLE_DURATION, SAMPLE_TOTAL
 from wm_infra.api.protocol import (
@@ -48,6 +49,9 @@ from wm_infra.api.protocol import (
     RolloutResponse,
     SSE_DONE,
     StepResult,
+    TransitionInitializeRequest,
+    TransitionPredictManyRequest,
+    TransitionPredictRequest,
 )
 from wm_infra.backends import BackendRegistry, CosmosJobQueue, CosmosPredictBackend, GenieJobQueue, GenieRolloutBackend, RolloutBackend, WanJobQueue, WanVideoBackend
 from wm_infra.backends.cosmos_runner import CosmosRunner
@@ -707,11 +711,72 @@ def create_app(
         items = manager.list_task_specs(env_name=env_name)
         return {"task_specs": [item.model_dump(mode="json") for item in items], "count": len(items)}
 
-    @app.post("/v1/envs")
-    async def create_env_session(request: EnvironmentCreateRequest):
+    def _mark_env_session_deprecated(response) -> None:
+        response.headers["Deprecation"] = "true"
+        response.headers["Warning"] = (
+            '299 - "The /v1/envs session API is deprecated; use /v1/transitions/initialize and '
+            '/v1/transitions/predict(_many) with explicit state_handle_id/trajectory_id."'
+        )
+
+    @app.post("/v1/transitions/initialize")
+    async def initialize_transition_context(request: TransitionInitializeRequest):
         manager: RLEnvironmentManager = app.state.rl_env_manager
         try:
-            response = manager.create_session(
+            response = manager.initialize_transition_context(
+                env_name=request.env_name,
+                task_id=request.task_id,
+                seed=request.seed,
+                policy_version=request.policy_version,
+                max_episode_steps=request.max_episode_steps,
+                branch_name=request.branch_name,
+                labels=request.labels,
+                metadata=request.metadata,
+            )
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=f"Unknown env or task: {exc.args[0]}") from exc
+        return response.model_dump(mode="json")
+
+    @app.post("/v1/transitions/predict")
+    async def predict_transition(request: TransitionPredictRequest):
+        manager: RLEnvironmentManager = app.state.rl_env_manager
+        try:
+            response = manager.predict_transition(
+                state_handle_id=request.state_handle_id,
+                action=request.action,
+                trajectory_id=request.trajectory_id,
+                policy_version=request.policy_version,
+                checkpoint=request.checkpoint,
+                max_episode_steps=request.max_episode_steps,
+                metadata=request.metadata,
+            )
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=f"State or trajectory not found: {exc.args[0]}") from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return response.model_dump(mode="json")
+
+    @app.post("/v1/transitions/predict_many")
+    async def predict_many_transitions(request: TransitionPredictManyRequest):
+        manager: RLEnvironmentManager = app.state.rl_env_manager
+        try:
+            response = manager.predict_many_transitions(
+                items=[item.model_dump(mode="python") for item in request.items],
+                policy_version=request.policy_version,
+                checkpoint=request.checkpoint,
+                metadata=request.metadata,
+            )
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=f"State or trajectory not found: {exc.args[0]}") from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return response.model_dump(mode="json")
+
+    @app.post("/v1/envs", deprecated=True)
+    async def create_env_session(request: EnvironmentCreateRequest, response: Response):
+        _mark_env_session_deprecated(response)
+        manager: RLEnvironmentManager = app.state.rl_env_manager
+        try:
+            session_response = manager.create_session(
                 env_name=request.env_name,
                 task_id=request.task_id,
                 seed=request.seed,
@@ -722,10 +787,11 @@ def create_app(
             )
         except KeyError as exc:
             raise HTTPException(status_code=404, detail=f"Unknown env or task: {exc.args[0]}") from exc
-        return response.model_dump(mode="json")
+        return session_response.model_dump(mode="json")
 
-    @app.get("/v1/envs")
-    async def list_env_sessions(status: str | None = None, task_id: str | None = None):
+    @app.get("/v1/envs", deprecated=True)
+    async def list_env_sessions(response: Response, status: str | None = None, task_id: str | None = None):
+        _mark_env_session_deprecated(response)
         manager: RLEnvironmentManager = app.state.rl_env_manager
         items = manager.list_sessions()
         if status is not None:
@@ -734,8 +800,9 @@ def create_app(
             items = [item for item in items if item.task_id == task_id]
         return {"envs": [item.model_dump(mode="json") for item in items], "count": len(items)}
 
-    @app.get("/v1/envs/{env_id}")
-    async def get_env_session(env_id: str):
+    @app.get("/v1/envs/{env_id}", deprecated=True)
+    async def get_env_session(env_id: str, response: Response):
+        _mark_env_session_deprecated(response)
         manager: RLEnvironmentManager = app.state.rl_env_manager
         try:
             session = manager.get_session(env_id)
@@ -743,11 +810,12 @@ def create_app(
             raise HTTPException(status_code=404, detail="Environment session not found") from exc
         return session.model_dump(mode="json")
 
-    @app.post("/v1/envs/{env_id}/reset")
-    async def reset_env_session(env_id: str, request: EnvironmentResetRequest):
+    @app.post("/v1/envs/{env_id}/reset", deprecated=True)
+    async def reset_env_session(env_id: str, request: EnvironmentResetRequest, response: Response):
+        _mark_env_session_deprecated(response)
         manager: RLEnvironmentManager = app.state.rl_env_manager
         try:
-            response = manager.reset_session(
+            reset_response = manager.reset_session(
                 env_id,
                 seed=request.seed,
                 policy_version=request.policy_version,
@@ -755,13 +823,14 @@ def create_app(
             )
         except KeyError as exc:
             raise HTTPException(status_code=404, detail="Environment session not found") from exc
-        return response.model_dump(mode="json")
+        return reset_response.model_dump(mode="json")
 
-    @app.post("/v1/envs/{env_id}/step")
-    async def step_env_session(env_id: str, request: EnvironmentStepRequest):
+    @app.post("/v1/envs/{env_id}/step", deprecated=True)
+    async def step_env_session(env_id: str, request: EnvironmentStepRequest, response: Response):
+        _mark_env_session_deprecated(response)
         manager: RLEnvironmentManager = app.state.rl_env_manager
         try:
-            response = manager.step_session(
+            step_response = manager.step_session(
                 env_id,
                 action=request.action,
                 policy_version=request.policy_version,
@@ -772,13 +841,14 @@ def create_app(
             raise HTTPException(status_code=404, detail="Environment session not found") from exc
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        return response.model_dump(mode="json")
+        return step_response.model_dump(mode="json")
 
-    @app.post("/v1/envs/{env_id}/step_many")
-    async def step_many_env_sessions(env_id: str, request: EnvironmentStepManyRequest):
+    @app.post("/v1/envs/{env_id}/step_many", deprecated=True)
+    async def step_many_env_sessions(env_id: str, request: EnvironmentStepManyRequest, response: Response):
+        _mark_env_session_deprecated(response)
         manager: RLEnvironmentManager = app.state.rl_env_manager
         try:
-            response = manager.step_many(
+            step_many_response = manager.step_many(
                 env_id,
                 env_ids=request.env_ids,
                 actions=request.actions,
@@ -790,13 +860,14 @@ def create_app(
             raise HTTPException(status_code=404, detail=f"Environment session not found: {exc.args[0]}") from exc
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        return response.model_dump(mode="json")
+        return step_many_response.model_dump(mode="json")
 
-    @app.post("/v1/envs/{env_id}/fork")
-    async def fork_env_session(env_id: str, request: EnvironmentForkRequest):
+    @app.post("/v1/envs/{env_id}/fork", deprecated=True)
+    async def fork_env_session(env_id: str, request: EnvironmentForkRequest, response: Response):
+        _mark_env_session_deprecated(response)
         manager: RLEnvironmentManager = app.state.rl_env_manager
         try:
-            response = manager.fork_session(
+            fork_response = manager.fork_session(
                 env_id,
                 branch_name=request.branch_name,
                 policy_version=request.policy_version,
@@ -804,10 +875,11 @@ def create_app(
             )
         except KeyError as exc:
             raise HTTPException(status_code=404, detail="Environment session not found") from exc
-        return response.model_dump(mode="json")
+        return fork_response.model_dump(mode="json")
 
-    @app.post("/v1/envs/{env_id}/checkpoint")
-    async def checkpoint_env_session(env_id: str, request: EnvironmentCheckpointRequest):
+    @app.post("/v1/envs/{env_id}/checkpoint", deprecated=True)
+    async def checkpoint_env_session(env_id: str, request: EnvironmentCheckpointRequest, response: Response):
+        _mark_env_session_deprecated(response)
         manager: RLEnvironmentManager = app.state.rl_env_manager
         try:
             checkpoint_id = manager.checkpoint_session(env_id, tag=request.tag, metadata=request.metadata)
@@ -818,8 +890,9 @@ def create_app(
         assert checkpoint is not None
         return checkpoint.model_dump(mode="json")
 
-    @app.delete("/v1/envs/{env_id}")
-    async def delete_env_session(env_id: str):
+    @app.delete("/v1/envs/{env_id}", deprecated=True)
+    async def delete_env_session(env_id: str, response: Response):
+        _mark_env_session_deprecated(response)
         manager: RLEnvironmentManager = app.state.rl_env_manager
         try:
             manager.delete_session(env_id)

--- a/wm_infra/rl/runtime.py
+++ b/wm_infra/rl/runtime.py
@@ -12,6 +12,9 @@ from wm_infra.api.protocol import (
     EnvironmentSessionResponse,
     EnvironmentStepManyResponse,
     EnvironmentStepResponse,
+    TransitionContextResponse,
+    TransitionPredictManyResponse,
+    TransitionPredictResponse,
 )
 from wm_infra.controlplane import (
     BranchCreate,
@@ -125,10 +128,8 @@ def _default_task_specs() -> list[TaskSpec]:
         ),
     ]
 
-
 @dataclass(slots=True)
-class _LiveSession:
-    env_id: str
+class _StatelessTransitionContext:
     env_name: str
     task_id: str
     episode_id: str
@@ -140,12 +141,12 @@ class _LiveSession:
     max_episode_steps: int
     state: torch.Tensor
     goal: torch.Tensor
-    step_idx: int = 0
-    needs_reset: bool = False
+    step_idx: int
+    scope_id: str
 
 
 class RLEnvironmentManager:
-    """Environment registry + live session manager for trainer-facing RL APIs."""
+    """Environment registry + stateless transition manager for trainer-facing RL APIs."""
 
     def __init__(self, temporal_store: TemporalStore, *, max_chunk_size: int = 32) -> None:
         self.temporal_store = temporal_store
@@ -154,7 +155,6 @@ class RLEnvironmentManager:
         self.max_chunk_size = max(1, max_chunk_size)
         self.world_model = ToyLineWorldModel(ToyLineWorldSpec(), device=self.device, dtype=self.dtype)
         self.genie_world_model = GenieWorldModelAdapter(device=self.device, spec=GenieRLSpec())
-        self._sessions: dict[str, _LiveSession] = {}
         self._env_specs = {spec.env_name: spec for spec in _default_environment_specs()}
         self._task_specs = {task.task_id: task for task in _default_task_specs()}
         self._register_catalog()
@@ -201,18 +201,72 @@ class RLEnvironmentManager:
         metadata: dict[str, Any],
     ) -> EnvironmentSessionResponse:
         spec = self._resolve_env_spec(env_name)
+        initialized = self.initialize_transition_context(
+            env_name=env_name,
+            task_id=task_id,
+            seed=seed,
+            policy_version=policy_version,
+            max_episode_steps=max_episode_steps,
+            branch_name="main",
+            labels=labels,
+            metadata=metadata,
+        )
+        session = self.temporal_store.create_environment_session(
+            EnvironmentSessionCreate(
+                env_name=env_name,
+                episode_id=initialized.episode_id,
+                task_id=initialized.task_id,
+                backend=spec.backend,
+                current_step=0,
+                state_handle_id=initialized.state_handle_id,
+                checkpoint_id=None,
+                trajectory_id=initialized.trajectory_id,
+                branch_id=initialized.branch_id,
+                policy_version=initialized.policy_version,
+                labels=labels,
+                metadata={
+                    "env_name": env_name,
+                    "task_split": self._resolve_task(initialized.task_id, env_name=env_name).split,
+                    "max_episode_steps": initialized.max_episode_steps,
+                    "needs_reset": False,
+                    "compat_session": True,
+                    **metadata,
+                },
+            )
+        )
+        trajectory = self.temporal_store.trajectories.get(initialized.trajectory_id)
+        assert trajectory is not None
+        trajectory.env_id = session.env_id
+        self.temporal_store.update_trajectory(trajectory)
+        return self._session_response(session)
+
+    def initialize_transition_context(
+        self,
+        *,
+        env_name: str,
+        task_id: str | None,
+        seed: int | None,
+        policy_version: str | None,
+        max_episode_steps: int | None,
+        branch_name: str | None,
+        labels: dict[str, str],
+        metadata: dict[str, Any],
+    ) -> TransitionContextResponse:
+        spec = self._resolve_env_spec(env_name)
         task = self._resolve_task(task_id or self._default_task_for_env(env_name), env_name=env_name)
         episode = self.temporal_store.create_episode(
             EpisodeCreate(
                 title=f"{env_name}:{task.task_id}",
-                metadata={"env_name": env_name, "task_id": task.task_id, **metadata},
+                labels=labels,
+                metadata={"env_name": env_name, "task_id": task.task_id, "stateless": True, **metadata},
             )
         )
         branch = self.temporal_store.create_branch(
             BranchCreate(
                 episode_id=episode.episode_id,
-                name="main",
-                metadata={"env_name": env_name, "task_id": task.task_id},
+                name=branch_name or "main",
+                labels=labels,
+                metadata={"env_name": env_name, "task_id": task.task_id, "stateless": True, **metadata},
             )
         )
         state, goal = self._sample_initial_state(task, seed)
@@ -225,49 +279,30 @@ class RLEnvironmentManager:
             task=task,
             env_name=env_name,
         )
-        trajectory = self.temporal_store.create_trajectory(
-            TrajectoryCreate(
-                env_id="pending",
-                episode_id=episode.episode_id,
-                task_id=task.task_id,
-                policy_version=policy_version,
-                metadata={"env_name": env_name},
-            )
-        )
-        session = self.temporal_store.create_environment_session(
-            EnvironmentSessionCreate(
-                env_name=env_name,
-                episode_id=episode.episode_id,
-                task_id=task.task_id,
-                backend=spec.backend,
-                current_step=0,
-                state_handle_id=state_handle.state_handle_id,
-                checkpoint_id=None,
-                trajectory_id=trajectory.trajectory_id,
-                branch_id=branch.branch_id,
-                policy_version=policy_version,
-                labels=labels,
-                metadata={"env_name": env_name, "task_split": task.split, **metadata},
-            )
-        )
-        trajectory.env_id = session.env_id
-        self.temporal_store.update_trajectory(trajectory)
-        live = _LiveSession(
-            env_id=session.env_id,
+        trajectory = self._ensure_stateless_trajectory(
             env_name=env_name,
-            task_id=task.task_id,
+            task=task,
             episode_id=episode.episode_id,
             branch_id=branch.branch_id,
-            trajectory_id=trajectory.trajectory_id,
-            state_handle_id=state_handle.state_handle_id,
-            checkpoint_id=None,
+            trajectory_id=None,
             policy_version=policy_version,
             max_episode_steps=max_episode_steps or spec.default_horizon,
-            state=state,
-            goal=goal,
+            metadata={"seed": seed, **metadata},
         )
-        self._sessions[session.env_id] = live
-        return self._session_response(session, live)
+        return TransitionContextResponse(
+            env_name=env_name,
+            episode_id=episode.episode_id,
+            task_id=task.task_id,
+            branch_id=branch.branch_id,
+            state_handle_id=state_handle.state_handle_id,
+            checkpoint_id=None,
+            trajectory_id=trajectory.trajectory_id,
+            current_step=0,
+            policy_version=policy_version,
+            max_episode_steps=int(trajectory.metadata.get("max_episode_steps", spec.default_horizon)),
+            observation=self._observation(state, goal),
+            info=self._session_info_for_env(env_name, goal, 0),
+        )
 
     def reset_session(
         self,
@@ -278,67 +313,40 @@ class RLEnvironmentManager:
         metadata: dict[str, Any],
     ) -> EnvironmentSessionResponse:
         session = self.get_session(env_id)
-        live = self._require_live_session(env_id)
         task = self._resolve_task(session.task_id, env_name=session.env_name)
-        self._finalize_trajectory(live.trajectory_id, success=False)
+        if session.trajectory_id:
+            self._finalize_trajectory(session.trajectory_id, success=False)
 
-        episode = self.temporal_store.create_episode(
-            EpisodeCreate(
-                title=f"{session.env_name}:{task.task_id}",
-                metadata={"env_id": env_id, "reset_from_episode_id": session.episode_id, **metadata},
-            )
-        )
-        branch = self.temporal_store.create_branch(
-            BranchCreate(
-                episode_id=episode.episode_id,
-                name="main",
-                metadata={"env_id": env_id, "reset": True},
-            )
-        )
-        state, goal = self._sample_initial_state(task, seed)
-        state_handle = self._persist_state_handle(
-            episode_id=episode.episode_id,
-            branch_id=branch.branch_id,
-            state=state,
-            goal=goal,
-            step_idx=0,
-            task=task,
+        initialized = self.initialize_transition_context(
             env_name=session.env_name,
+            task_id=session.task_id,
+            seed=seed,
+            policy_version=policy_version or session.policy_version,
+            max_episode_steps=int(session.metadata.get("max_episode_steps", self._resolve_env_spec(session.env_name).default_horizon)),
+            branch_name="main",
+            labels=dict(session.labels),
+            metadata={"env_id": env_id, "reset_from_episode_id": session.episode_id, **metadata},
         )
-        trajectory = self.temporal_store.create_trajectory(
-            TrajectoryCreate(
-                env_id=env_id,
-                episode_id=episode.episode_id,
-                task_id=task.task_id,
-                policy_version=policy_version or live.policy_version,
-                metadata={"env_name": session.env_name, "reset": True},
-            )
-        )
-        live.state = state
-        live.goal = goal
-        live.step_idx = 0
-        live.needs_reset = False
-        live.episode_id = episode.episode_id
-        live.branch_id = branch.branch_id
-        live.state_handle_id = state_handle.state_handle_id
-        live.trajectory_id = trajectory.trajectory_id
-        live.checkpoint_id = None
-        if policy_version is not None:
-            live.policy_version = policy_version
+        trajectory = self.temporal_store.trajectories.get(initialized.trajectory_id)
+        assert trajectory is not None
+        trajectory.env_id = env_id
+        self.temporal_store.update_trajectory(trajectory)
 
-        session.episode_id = episode.episode_id
-        session.branch_id = branch.branch_id
+        session.episode_id = initialized.episode_id
+        session.branch_id = initialized.branch_id
         session.current_step = 0
-        session.state_handle_id = state_handle.state_handle_id
-        session.trajectory_id = trajectory.trajectory_id
+        session.state_handle_id = initialized.state_handle_id
+        session.trajectory_id = initialized.trajectory_id
         session.checkpoint_id = None
-        session.policy_version = live.policy_version
+        session.policy_version = initialized.policy_version
         session.completed_at = None
         session.status = TemporalStatus.ACTIVE
         session.metadata["needs_reset"] = False
+        session.metadata["max_episode_steps"] = initialized.max_episode_steps
+        session.metadata["task_split"] = task.split
         session.metadata.update(metadata)
         session = self.temporal_store.update_environment_session(session)
-        return self._session_response(session, live)
+        return self._session_response(session)
 
     def step_session(
         self,
@@ -373,11 +381,11 @@ class RLEnvironmentManager:
         if len(ordered_env_ids) != len(actions):
             raise ValueError("step_many requires one action per env_id")
 
-        sessions = [self._require_live_session(item) for item in ordered_env_ids]
-        if any(session.needs_reset for session in sessions):
+        session_records = [self.get_session(item) for item in ordered_env_ids]
+        if any(bool(session.metadata.get("needs_reset")) for session in session_records):
             raise ValueError("All sessions in step_many must be reset before further stepping")
-        env_name = sessions[0].env_name
-        if any(session.env_name != env_name for session in sessions):
+        env_name = session_records[0].env_name
+        if any(session.env_name != env_name for session in session_records):
             raise ValueError("step_many currently only supports batching the same env_name")
 
         action_tensor = torch.as_tensor(actions, dtype=self.dtype, device=self.device).view(len(actions), -1)
@@ -385,16 +393,127 @@ class RLEnvironmentManager:
         if action_tensor.shape[1] != expected_action_dim:
             raise ValueError(f"Expected action_dim={expected_action_dim}, got {action_tensor.shape[1]}")
 
+        prediction = self.predict_many_transitions(
+            items=[
+                {
+                    "state_handle_id": session.state_handle_id,
+                    "trajectory_id": session.trajectory_id,
+                    "action": action,
+                    "max_episode_steps": int(session.metadata.get("max_episode_steps", self._resolve_env_spec(session.env_name).default_horizon)),
+                }
+                for session, action in zip(session_records, actions, strict=True)
+            ],
+            policy_version=policy_version,
+            checkpoint=checkpoint,
+            metadata=metadata,
+        )
+
         responses: list[EnvironmentStepResponse] = []
+        chunk_ids = [chunk["chunk_id"] for chunk in prediction.runtime.get("chunks", [])]
+        for index, (session, result) in enumerate(zip(session_records, prediction.results, strict=True)):
+            session.current_step = result.step_idx
+            session.state_handle_id = result.state_handle_id
+            session.checkpoint_id = result.checkpoint_id
+            session.policy_version = result.policy_version
+            session.metadata["needs_reset"] = result.terminated or result.truncated
+            session.metadata["last_transition_id"] = result.transition_id
+            if chunk_ids:
+                session.metadata["last_chunk_id"] = chunk_ids[min(index // self.max_chunk_size, len(chunk_ids) - 1)]
+            session = self.temporal_store.update_environment_session(session)
+            responses.append(
+                EnvironmentStepResponse(
+                    env_id=session.env_id,
+                    episode_id=result.episode_id,
+                    task_id=result.task_id,
+                    trajectory_id=result.trajectory_id,
+                    state_handle_id=result.state_handle_id,
+                    checkpoint_id=result.checkpoint_id,
+                    transition_id=result.transition_id,
+                    policy_version=result.policy_version,
+                    step_idx=result.step_idx,
+                    observation=result.observation,
+                    reward=result.reward,
+                    terminated=result.terminated,
+                    truncated=result.truncated,
+                    info=result.info,
+                )
+            )
+
+        runtime = dict(prediction.runtime)
+        runtime["execution_path"] = "chunked_env_step"
+        runtime["env_step_chunk_total"] = runtime.get("chunk_count", 0)
+        runtime["state_locality_mode"] = "legacy_env_wrapper"
+        return EnvironmentStepManyResponse(
+            env_ids=ordered_env_ids,
+            results=responses,
+            runtime=runtime,
+        )
+
+    def predict_transition(
+        self,
+        *,
+        state_handle_id: str,
+        action: list[float],
+        trajectory_id: str | None,
+        policy_version: str | None,
+        checkpoint: bool,
+        max_episode_steps: int | None,
+        metadata: dict[str, Any],
+    ) -> TransitionPredictResponse:
+        response = self.predict_many_transitions(
+            items=[{
+                "state_handle_id": state_handle_id,
+                "action": action,
+                "trajectory_id": trajectory_id,
+                "max_episode_steps": max_episode_steps,
+            }],
+            policy_version=policy_version,
+            checkpoint=checkpoint,
+            metadata=metadata,
+        )
+        return response.results[0]
+
+    def predict_many_transitions(
+        self,
+        *,
+        items: list[dict[str, Any]],
+        policy_version: str | None,
+        checkpoint: bool,
+        metadata: dict[str, Any],
+    ) -> TransitionPredictManyResponse:
+        if not items:
+            raise ValueError("predict_many requires at least one item")
+
+        contexts = [
+            self._load_stateless_context(
+                state_handle_id=str(item["state_handle_id"]),
+                trajectory_id=item.get("trajectory_id"),
+                max_episode_steps=item.get("max_episode_steps"),
+                policy_version=policy_version,
+            )
+            for item in items
+        ]
+        env_name = contexts[0].env_name
+        if any(context.env_name != env_name for context in contexts):
+            raise ValueError("predict_many currently only supports batching the same env_name")
+
+        actions = [item["action"] for item in items]
+        action_tensor = torch.as_tensor(actions, dtype=self.dtype, device=self.device).view(len(actions), -1)
+        expected_action_dim = self._action_dim_for_env(env_name)
+        if action_tensor.shape[1] != expected_action_dim:
+            raise ValueError(f"Expected action_dim={expected_action_dim}, got {action_tensor.shape[1]}")
+
         reward_stage_ms = 0.0
         trajectory_persist_ms = 0.0
         chunk_sizes: list[int] = []
         chunk_history: list[dict[str, Any]] = []
-        step_chunks = self._build_step_chunks(ordered_env_ids, sessions, action_tensor)
+        responses: list[TransitionPredictResponse] = []
+        step_chunks = self._build_stateless_step_chunks(contexts, action_tensor)
+        context_by_id = {context.state_handle_id: context for context in contexts}
         reward_fn = self._reward_fn_for_env(env_name)
         world_model = self._world_model_for_env(env_name)
 
-        for chunk_index, chunk in enumerate(step_chunks):
+        for chunk in step_chunks:
             chunk_sizes.append(chunk.size)
             chunk_history.append(
                 {
@@ -407,69 +526,72 @@ class RLEnvironmentManager:
 
             reward_started_at = time.perf_counter()
             next_states = world_model.predict_next(chunk.latent_batch, chunk.action_batch)
-            goal_batch = torch.cat([self._require_live_session(entity.rollout_id).goal for entity in chunk.entities], dim=0)
+            chunk_contexts = [context_by_id[entity.rollout_id] for entity in chunk.entities]
+            goal_batch = torch.cat([context.goal for context in chunk_contexts], dim=0)
             rewards, terminated, info_tensors = reward_fn.evaluate(next_states, goal_batch)
             reward_stage_ms += (time.perf_counter() - reward_started_at) * 1000.0
 
             persist_started_at = time.perf_counter()
-            for index, entity in enumerate(chunk.entities):
-                session_id = entity.rollout_id
-                live = self._require_live_session(session_id)
-                session = self.get_session(session_id)
-                task = self._resolve_task(live.task_id, env_name=live.env_name)
-                step_idx = live.step_idx
+            for index, context in enumerate(chunk_contexts):
+                task = self._resolve_task(context.task_id, env_name=context.env_name)
                 reward = float(rewards[index].item())
                 is_terminated = bool(terminated[index].item())
-                next_step_idx = step_idx + 1
-                is_truncated = next_step_idx >= live.max_episode_steps
+                next_step_idx = context.step_idx + 1
+                is_truncated = next_step_idx >= context.max_episode_steps
                 next_state = next_states[index:index + 1]
                 next_handle = self._persist_state_handle(
-                    episode_id=live.episode_id,
-                    branch_id=live.branch_id,
+                    episode_id=context.episode_id,
+                    branch_id=context.branch_id,
                     state=next_state,
-                    goal=live.goal,
+                    goal=context.goal,
                     step_idx=next_step_idx,
                     task=task,
-                    env_name=live.env_name,
+                    env_name=context.env_name,
                 )
                 info = self._transition_info_for_env(
-                    env_name,
-                    goal=live.goal,
+                    context.env_name,
+                    goal=context.goal,
                     info_tensors=info_tensors,
                     index=index,
                     step_idx=next_step_idx,
                 )
                 transition = self.temporal_store.create_transition(
                     TransitionCreate(
-                        env_id=session_id,
-                        episode_id=live.episode_id,
-                        trajectory_id=live.trajectory_id,
-                        task_id=live.task_id,
-                        step_idx=step_idx,
-                        observation_ref=live.state_handle_id,
+                        env_id=context.scope_id,
+                        episode_id=context.episode_id,
+                        trajectory_id=context.trajectory_id,
+                        task_id=context.task_id,
+                        step_idx=context.step_idx,
+                        observation_ref=context.state_handle_id,
                         action=list(chunk.action_batch[index].detach().cpu().numpy().tolist()),
                         reward=reward,
                         terminated=is_terminated,
                         truncated=is_truncated,
                         next_observation_ref=next_handle.state_handle_id,
                         info={**info, **metadata},
-                        policy_version=policy_version or live.policy_version,
-                        metadata={"batched": len(sessions) > 1, "chunk_id": chunk.chunk_id},
+                        policy_version=policy_version or context.policy_version,
+                        metadata={"batched": len(contexts) > 1, "chunk_id": chunk.chunk_id, "stateless": True},
                     )
                 )
                 checkpoint_id = None
-                live.state = next_state
-                live.state_handle_id = next_handle.state_handle_id
-                live.step_idx = next_step_idx
-                if policy_version is not None:
-                    live.policy_version = policy_version
                 if checkpoint or is_terminated or is_truncated:
-                    checkpoint_id = self._checkpoint_live_session(
-                        live,
+                    checkpoint_id = self._checkpoint_state_handle(
+                        state_handle_id=next_handle.state_handle_id,
+                        episode_id=context.episode_id,
+                        branch_id=context.branch_id,
+                        step_idx=next_step_idx,
                         tag=f"step-{next_step_idx}",
-                        metadata={"batched": len(sessions) > 1, "chunk_id": chunk.chunk_id, **metadata},
+                        metadata={
+                            "env_name": context.env_name,
+                            "task_id": context.task_id,
+                            "trajectory_id": context.trajectory_id,
+                            "batched": len(contexts) > 1,
+                            "chunk_id": chunk.chunk_id,
+                            "stateless": True,
+                            **metadata,
+                        },
                     )
-                trajectory = self.temporal_store.trajectories.get(live.trajectory_id)
+                trajectory = self.temporal_store.trajectories.get(context.trajectory_id)
                 assert trajectory is not None
                 trajectory.num_steps += 1
                 trajectory.return_value += reward
@@ -482,29 +604,20 @@ class RLEnvironmentManager:
                     trajectory.status = TemporalStatus.ARCHIVED
                     trajectory.completed_at = time.time()
                 self.temporal_store.update_trajectory(trajectory)
-
-                session.current_step = next_step_idx
-                session.state_handle_id = next_handle.state_handle_id
-                session.checkpoint_id = checkpoint_id
-                session.policy_version = live.policy_version
-                session.metadata["needs_reset"] = is_terminated or is_truncated
-                session.metadata["last_transition_id"] = transition.transition_id
-                session.metadata["last_chunk_id"] = chunk.chunk_id
-                if is_terminated or is_truncated:
-                    live.needs_reset = True
-                session = self.temporal_store.update_environment_session(session)
                 responses.append(
-                    EnvironmentStepResponse(
-                        env_id=session_id,
-                        episode_id=live.episode_id,
-                        task_id=live.task_id,
-                        trajectory_id=live.trajectory_id,
+                    TransitionPredictResponse(
+                        env_name=context.env_name,
+                        episode_id=context.episode_id,
+                        task_id=context.task_id,
+                        branch_id=context.branch_id,
+                        trajectory_id=context.trajectory_id,
                         state_handle_id=next_handle.state_handle_id,
                         checkpoint_id=checkpoint_id,
                         transition_id=transition.transition_id,
-                        policy_version=live.policy_version,
+                        policy_version=policy_version or context.policy_version,
                         step_idx=next_step_idx,
-                        observation=self._observation(next_state, live.goal),
+                        max_episode_steps=context.max_episode_steps,
+                        observation=self._observation(next_state, context.goal),
                         reward=reward,
                         terminated=is_terminated,
                         truncated=is_truncated,
@@ -512,20 +625,19 @@ class RLEnvironmentManager:
                     )
                 )
             trajectory_persist_ms += (time.perf_counter() - persist_started_at) * 1000.0
-        return EnvironmentStepManyResponse(
-            env_ids=ordered_env_ids,
+
+        return TransitionPredictManyResponse(
             results=responses,
             runtime={
-                "execution_path": "chunked_env_step",
-                "env_step_chunk_total": len(step_chunks),
+                "execution_path": "chunked_stateless_transition",
                 "chunk_count": len(step_chunks),
                 "chunk_sizes": chunk_sizes,
                 "max_chunk_size": max(chunk_sizes) if chunk_sizes else 0,
                 "avg_chunk_size": (sum(chunk_sizes) / len(chunk_sizes)) if chunk_sizes else 0.0,
                 "reward_stage_ms": reward_stage_ms,
                 "trajectory_persist_ms": trajectory_persist_ms,
-                "state_locality_hit_rate": 1.0,
-                "state_locality_mode": "in_process_live_session",
+                "state_locality_hit_rate": 0.0,
+                "state_locality_mode": "explicit_state_handle",
                 "chunks": chunk_history,
             },
         )
@@ -538,81 +650,82 @@ class RLEnvironmentManager:
         policy_version: str | None,
         metadata: dict[str, Any],
     ) -> EnvironmentSessionResponse:
-        source = self._require_live_session(env_id)
         source_record = self.get_session(env_id)
+        context = self._load_stateless_context(
+            state_handle_id=source_record.state_handle_id,
+            trajectory_id=source_record.trajectory_id,
+            max_episode_steps=int(source_record.metadata.get("max_episode_steps", self._resolve_env_spec(source_record.env_name).default_horizon)),
+            policy_version=policy_version or source_record.policy_version,
+        )
         branch = self.temporal_store.create_branch(
             BranchCreate(
-                episode_id=source.episode_id,
-                parent_branch_id=source.branch_id,
-                forked_from_checkpoint_id=source.checkpoint_id,
-                name=branch_name or f"fork-{source.step_idx}",
+                episode_id=context.episode_id,
+                parent_branch_id=context.branch_id,
+                forked_from_checkpoint_id=source_record.checkpoint_id,
+                name=branch_name or f"fork-{context.step_idx}",
                 metadata={"source_env_id": env_id, **metadata},
             )
         )
         state_handle = self._persist_state_handle(
-            episode_id=source.episode_id,
+            episode_id=context.episode_id,
             branch_id=branch.branch_id,
-            state=source.state.clone(),
-            goal=source.goal.clone(),
-            step_idx=source.step_idx,
-            task=self._resolve_task(source.task_id, env_name=source.env_name),
-            env_name=source.env_name,
+            state=context.state.clone(),
+            goal=context.goal.clone(),
+            step_idx=context.step_idx,
+            task=self._resolve_task(context.task_id, env_name=context.env_name),
+            env_name=context.env_name,
         )
-        trajectory = self.temporal_store.create_trajectory(
-            TrajectoryCreate(
-                env_id="pending",
-                episode_id=source.episode_id,
-                task_id=source.task_id,
-                policy_version=policy_version or source.policy_version,
-                metadata={"forked_from_env_id": env_id},
-            )
+        trajectory = self._ensure_stateless_trajectory(
+            env_name=context.env_name,
+            task=self._resolve_task(context.task_id, env_name=context.env_name),
+            episode_id=context.episode_id,
+            branch_id=branch.branch_id,
+            trajectory_id=None,
+            policy_version=policy_version or context.policy_version,
+            max_episode_steps=context.max_episode_steps,
+            metadata={"forked_from_env_id": env_id},
         )
         session = self.temporal_store.create_environment_session(
             EnvironmentSessionCreate(
-                env_name=source.env_name,
-                episode_id=source.episode_id,
-                task_id=source.task_id,
+                env_name=context.env_name,
+                episode_id=context.episode_id,
+                task_id=context.task_id,
                 backend=source_record.backend,
-                current_step=source.step_idx,
+                current_step=context.step_idx,
                 state_handle_id=state_handle.state_handle_id,
-                checkpoint_id=source.checkpoint_id,
+                checkpoint_id=source_record.checkpoint_id,
                 trajectory_id=trajectory.trajectory_id,
                 branch_id=branch.branch_id,
-                policy_version=policy_version or source.policy_version,
+                policy_version=policy_version or context.policy_version,
                 labels=dict(source_record.labels),
-                metadata={"forked_from_env_id": env_id, **metadata},
+                metadata={
+                    "forked_from_env_id": env_id,
+                    "max_episode_steps": context.max_episode_steps,
+                    "needs_reset": False,
+                    "compat_session": True,
+                    **metadata,
+                },
             )
         )
         trajectory.env_id = session.env_id
         self.temporal_store.update_trajectory(trajectory)
-        live = _LiveSession(
-            env_id=session.env_id,
-            env_name=source.env_name,
-            task_id=source.task_id,
-            episode_id=source.episode_id,
-            branch_id=branch.branch_id,
-            trajectory_id=trajectory.trajectory_id,
-            state_handle_id=state_handle.state_handle_id,
-            checkpoint_id=source.checkpoint_id,
-            policy_version=policy_version or source.policy_version,
-            max_episode_steps=source.max_episode_steps,
-            state=source.state.clone(),
-            goal=source.goal.clone(),
-            step_idx=source.step_idx,
-            needs_reset=source.needs_reset,
-        )
-        self._sessions[session.env_id] = live
-        return self._session_response(session, live)
+        return self._session_response(session)
 
     def checkpoint_session(self, env_id: str, *, tag: str | None, metadata: dict[str, Any]) -> str:
-        live = self._require_live_session(env_id)
-        return self._checkpoint_live_session(live, tag=tag or f"step-{live.step_idx}", metadata=metadata)
+        session = self.get_session(env_id)
+        return self._checkpoint_state_handle(
+            state_handle_id=session.state_handle_id,
+            episode_id=session.episode_id,
+            branch_id=session.branch_id or "",
+            step_idx=session.current_step,
+            tag=tag or f"step-{session.current_step}",
+            metadata={"env_name": session.env_name, "task_id": session.task_id, **metadata},
+        )
 
     def delete_session(self, env_id: str) -> None:
         session = self.get_session(env_id)
-        live = self._sessions.pop(env_id, None)
-        if live is not None:
-            self._finalize_trajectory(live.trajectory_id, success=False)
+        if session.trajectory_id:
+            self._finalize_trajectory(session.trajectory_id, success=False)
         session.status = TemporalStatus.ARCHIVED
         session.completed_at = time.time()
         self.temporal_store.update_environment_session(session)
@@ -636,7 +749,8 @@ class RLEnvironmentManager:
     def list_evaluation_runs(self) -> list[Any]:
         return self.temporal_store.evaluation_runs.list()
 
-    def _session_response(self, session: EnvironmentSessionRecord, live: _LiveSession) -> EnvironmentSessionResponse:
+    def _session_response(self, session: EnvironmentSessionRecord) -> EnvironmentSessionResponse:
+        state, goal, _step_idx = self._load_state_goal_from_handle(session.state_handle_id)
         return EnvironmentSessionResponse(
             env_id=session.env_id,
             env_name=session.env_name,
@@ -649,8 +763,8 @@ class RLEnvironmentManager:
             current_step=session.current_step,
             policy_version=session.policy_version,
             status=session.status.value,
-            observation=self._observation(live.state, live.goal),
-            info=self._session_info_for_env(session.env_name, live.goal, live.step_idx),
+            observation=self._observation(state, goal),
+            info=self._session_info_for_env(session.env_name, goal, session.current_step),
         )
 
     def _sample_initial_state(self, task: TaskSpec, seed: int | None) -> tuple[torch.Tensor, torch.Tensor]:
@@ -709,27 +823,6 @@ class RLEnvironmentManager:
             )
         )
 
-    def _checkpoint_live_session(self, live: _LiveSession, *, tag: str, metadata: dict[str, Any]) -> str:
-        checkpoint = self.temporal_store.create_checkpoint(
-            CheckpointCreate(
-                episode_id=live.episode_id,
-                branch_id=live.branch_id,
-                state_handle_id=live.state_handle_id,
-                step_index=live.step_idx,
-                tag=tag,
-                metadata={"env_name": live.env_name, "task_id": live.task_id, **metadata},
-            )
-        )
-        live.checkpoint_id = checkpoint.checkpoint_id
-        session = self.get_session(live.env_id)
-        session.checkpoint_id = checkpoint.checkpoint_id
-        self.temporal_store.update_environment_session(session)
-        state_handle = self.temporal_store.state_handles.get(live.state_handle_id)
-        if state_handle is not None:
-            state_handle.checkpoint_id = checkpoint.checkpoint_id
-            self.temporal_store.state_handles.put(state_handle)
-        return checkpoint.checkpoint_id
-
     def _finalize_trajectory(self, trajectory_id: str, *, success: bool) -> None:
         trajectory = self.temporal_store.trajectories.get(trajectory_id)
         if trajectory is None or trajectory.completed_at is not None:
@@ -739,11 +832,138 @@ class RLEnvironmentManager:
         trajectory.completed_at = time.time()
         self.temporal_store.update_trajectory(trajectory)
 
-    def _require_live_session(self, env_id: str) -> _LiveSession:
-        session = self._sessions.get(env_id)
-        if session is None:
-            raise KeyError(env_id)
-        return session
+    def _checkpoint_state_handle(
+        self,
+        *,
+        state_handle_id: str,
+        episode_id: str,
+        branch_id: str | None,
+        step_idx: int,
+        tag: str,
+        metadata: dict[str, Any],
+    ) -> str:
+        checkpoint = self.temporal_store.create_checkpoint(
+            CheckpointCreate(
+                episode_id=episode_id,
+                branch_id=branch_id,
+                state_handle_id=state_handle_id,
+                step_index=step_idx,
+                tag=tag,
+                metadata=metadata,
+            )
+        )
+        state_handle = self.temporal_store.state_handles.get(state_handle_id)
+        if state_handle is not None:
+            state_handle.checkpoint_id = checkpoint.checkpoint_id
+            self.temporal_store.state_handles.put(state_handle)
+        return checkpoint.checkpoint_id
+
+    def _load_state_goal_from_handle(self, state_handle_id: str) -> tuple[torch.Tensor, torch.Tensor, int]:
+        state_handle = self.temporal_store.state_handles.get(state_handle_id)
+        if state_handle is None:
+            raise KeyError(state_handle_id)
+        metadata = state_handle.metadata
+        if "latent_state" not in metadata or "goal_state" not in metadata:
+            raise ValueError(f"state_handle {state_handle_id} is missing latent_state/goal_state metadata")
+        state = torch.as_tensor(metadata["latent_state"], dtype=self.dtype, device=self.device).unsqueeze(0)
+        goal = torch.as_tensor(metadata["goal_state"], dtype=self.dtype, device=self.device).unsqueeze(0)
+        step_idx = int(metadata.get("step_idx", 0))
+        return state, goal, step_idx
+
+    def _load_stateless_context(
+        self,
+        *,
+        state_handle_id: str,
+        trajectory_id: str | None,
+        max_episode_steps: int | None,
+        policy_version: str | None,
+    ) -> _StatelessTransitionContext:
+        state_handle = self.temporal_store.state_handles.get(state_handle_id)
+        if state_handle is None:
+            raise KeyError(state_handle_id)
+        metadata = state_handle.metadata
+        env_name = str(metadata.get("env_name"))
+        task_id = str(metadata.get("task_id"))
+        if not env_name or env_name == "None":
+            raise ValueError(f"state_handle {state_handle_id} is missing metadata.env_name")
+        if not task_id or task_id == "None":
+            raise ValueError(f"state_handle {state_handle_id} is missing metadata.task_id")
+        if state_handle.branch_id is None:
+            raise ValueError(f"state_handle {state_handle_id} is missing branch_id")
+        state, goal, step_idx = self._load_state_goal_from_handle(state_handle_id)
+        task = self._resolve_task(task_id, env_name=env_name)
+        spec = self._resolve_env_spec(env_name)
+        trajectory = self._ensure_stateless_trajectory(
+            env_name=env_name,
+            task=task,
+            episode_id=state_handle.episode_id,
+            branch_id=state_handle.branch_id,
+            trajectory_id=trajectory_id,
+            policy_version=policy_version,
+            max_episode_steps=max_episode_steps or spec.default_horizon,
+            metadata={"source_state_handle_id": state_handle_id},
+        )
+        return _StatelessTransitionContext(
+            env_name=env_name,
+            task_id=task_id,
+            episode_id=state_handle.episode_id,
+            branch_id=state_handle.branch_id,
+            trajectory_id=trajectory.trajectory_id,
+            state_handle_id=state_handle_id,
+            checkpoint_id=state_handle.checkpoint_id,
+            policy_version=policy_version or trajectory.policy_version,
+            max_episode_steps=int(trajectory.metadata.get("max_episode_steps", max_episode_steps or spec.default_horizon)),
+            state=state,
+            goal=goal,
+            step_idx=step_idx,
+            scope_id=trajectory.env_id,
+        )
+
+    def _ensure_stateless_trajectory(
+        self,
+        *,
+        env_name: str,
+        task: TaskSpec,
+        episode_id: str,
+        branch_id: str,
+        trajectory_id: str | None,
+        policy_version: str | None,
+        max_episode_steps: int,
+        metadata: dict[str, Any],
+    ) -> TrajectoryRecord:
+        if trajectory_id is not None:
+            trajectory = self.temporal_store.trajectories.get(trajectory_id)
+            if trajectory is None:
+                raise KeyError(trajectory_id)
+            if trajectory.episode_id != episode_id:
+                raise ValueError("trajectory_id does not belong to the requested episode/state")
+            if trajectory.task_id != task.task_id:
+                raise ValueError("trajectory_id does not match the requested task")
+            if policy_version is not None and trajectory.policy_version != policy_version:
+                trajectory.policy_version = policy_version
+                self.temporal_store.update_trajectory(trajectory)
+            if "max_episode_steps" not in trajectory.metadata:
+                trajectory.metadata["max_episode_steps"] = max_episode_steps
+                self.temporal_store.update_trajectory(trajectory)
+            return trajectory
+
+        scope_id = f"stateless:{episode_id}:{branch_id}"
+        return self.temporal_store.create_trajectory(
+            TrajectoryCreate(
+                env_id=scope_id,
+                episode_id=episode_id,
+                task_id=task.task_id,
+                policy_version=policy_version,
+                metadata={
+                    "env_name": env_name,
+                    "branch_id": branch_id,
+                    "task_split": task.split,
+                    "max_episode_steps": max_episode_steps,
+                    "stateless": True,
+                    **metadata,
+                },
+            )
+        )
 
     def _world_model_for_env(self, env_name: str):
         if env_name == "genie-token-grid-v0":
@@ -796,43 +1016,41 @@ class RLEnvironmentManager:
         info["success"] = bool(info_tensors["success"][index].item() > 0)
         return info
 
-    def _build_step_chunks(
+    def _build_stateless_step_chunks(
         self,
-        env_ids: list[str],
-        sessions: list[_LiveSession],
+        contexts: list[_StatelessTransitionContext],
         action_tensor: torch.Tensor,
     ) -> list[ExecutionChunk]:
-        if not env_ids:
+        if not contexts:
             return []
         signature = BatchSignature(
-            stage="env_step",
-            latent_shape=tuple(sessions[0].state.shape[-2:]),
+            stage="stateless_transition",
+            latent_shape=tuple(contexts[0].state.shape[-2:]),
             action_dim=int(action_tensor.shape[-1]),
             dtype=str(self.dtype).replace("torch.", ""),
             device=str(self.device),
             needs_decode=False,
         )
         chunks: list[ExecutionChunk] = []
-        for offset in range(0, len(env_ids), self.max_chunk_size):
-            chunk_env_ids = env_ids[offset:offset + self.max_chunk_size]
-            chunk_sessions = sessions[offset:offset + self.max_chunk_size]
+        for offset in range(0, len(contexts), self.max_chunk_size):
+            chunk_contexts = contexts[offset:offset + self.max_chunk_size]
             chunk_actions = action_tensor[offset:offset + self.max_chunk_size]
             chunk_entities = [
                 ExecutionEntity(
-                    entity_id=f"{env_id}:env_step:{session.step_idx}",
-                    rollout_id=env_id,
-                    stage="env_step",
-                    step_idx=session.step_idx,
+                    entity_id=f"{context.state_handle_id}:transition:{context.step_idx}",
+                    rollout_id=context.state_handle_id,
+                    stage="stateless_transition",
+                    step_idx=context.step_idx,
                     batch_signature=signature,
                 )
-                for env_id, session in zip(chunk_env_ids, chunk_sessions, strict=True)
+                for context in chunk_contexts
             ]
             chunks.append(
                 ExecutionChunk(
-                    chunk_id=f"env_step:{offset // self.max_chunk_size}",
+                    chunk_id=f"stateless_transition:{offset // self.max_chunk_size}",
                     signature=signature,
                     entities=chunk_entities,
-                    latent_batch=torch.cat([session.state for session in chunk_sessions], dim=0),
+                    latent_batch=torch.cat([context.state for context in chunk_contexts], dim=0),
                     action_batch=chunk_actions,
                 )
             )


### PR DESCRIPTION
## What changed

This PR refactors the trainer-facing RL API toward an explicit stateless transition model.

It adds a new northbound transition surface:

- `POST /v1/transitions/initialize`
- `POST /v1/transitions/predict`
- `POST /v1/transitions/predict_many`

These routes continue execution through explicit durable resource IDs such as `state_handle_id` and `trajectory_id` instead of relying on server-owned live session state.

The legacy `/v1/envs*` routes are still present, but they are now deprecated compatibility wrappers and no longer carry a separate session-driven execution path internally.

## Why it changed

The repo is moving toward a stateless public API shape while still preserving durable temporal control-plane objects.

For trainer and rollout workloads, the important persistent objects are things like:

- `episode`
- `branch`
- `state_handle`
- `checkpoint`
- `trajectory`

Those should remain durable, but the API should not require a server-side in-memory session to continue stepping. This PR makes that distinction explicit.

## User and developer impact

For new integrations:

- prefer the `/v1/transitions/*` routes
- continue work by passing `state_handle_id` and `trajectory_id` explicitly
- do not rely on `/v1/envs*` as the default northbound contract

For existing integrations:

- `/v1/envs*` still works
- responses now include deprecation headers to steer callers toward the stateless transition surface

For maintainers:

- the duplicated live-session execution path has been removed from `wm_infra/rl/runtime.py`
- legacy env-session handlers now wrap the stateless transition flow instead of maintaining a parallel runtime path
- docs and tests were updated to reflect the new preferred contract

## Root cause

The previous trainer-facing API mixed two concerns:

- durable temporal state that should be persisted
- live in-memory env sessions that should not define the public API contract

That made the northbound API more stateful than necessary and forced the runtime to maintain two overlapping execution models.

## Validation

Ran:

```bash
pytest tests/test_rl_runtime.py tests/test_rl_api.py tests/test_server.py
```

Result:

- 47 tests passed
