### PR TITLE
perf(cosmos): generation is launch/bandwidth-bound — add profiler, to…

### DIFF
--- a/docs/sprints/info/SPRINT_cosmos_generation_compile_bottleneck.md
+++ b/docs/sprints/info/SPRINT_cosmos_generation_compile_bottleneck.md
@@ -1,0 +1,90 @@
+# SPRINT: Cosmos generation is launch/bandwidth-bound — torch.compile = 1.68×
+
+状态：info / measured（2026-06-18，单 L40S 46GB）。结论可直接落地：**给 Cosmos
+Predict2.5 rollout 打开 `model.torch_compile.enable=true`**。
+
+> 起因：paper-parity run（512p/93f/20-step）单卡生成 ~58s/video，问"吞吐到顶了吗、
+> 怎么判断、能不能提"。下面是用 profiler 实测出的答案。
+
+## 0. TL;DR
+
+- 生成 forward **不是 compute-bound**，是 **kernel-launch + 显存带宽 bound**：每个 denoise
+  step 启动 **5,122 个 kernel**，**57% 设备时间花在小 elementwise kernel** 上，`dmon` MEM%
+  持续 **~82%**。
+- **`torch.compile`(default) 把它融合掉 → 1.68× 提速**（57.5→34.3 s/video）。kernel 启动
+  **5,122→2,832/step（-45%）**，elementwise 时间 **57%→13%**，MEM% **82%→48%**。
+- 单卡纯生成全程（65,536 rollout）：~46d → **~27d**。compile 是免费的；多卡数据并行仍是
+  数量级杠杆，叠加在 compile 之上。
+
+## 1. 怎么判断"吞吐到没到顶"（方法论）
+
+`nvidia-smi` 的 **GPU-util% 会骗人**：一个带宽受限的小 kernel 也能让 util 长期 100%。可靠信号
+按强度排序：
+
+| 信号 | 看什么 | 可靠性 |
+|---|---|---|
+| util% | 100% | 弱（必要不充分；≠ 峰值 FLOPS） |
+| 功耗 / SM 时钟 | 近功耗墙 + 满频 = 密集算力 | 中 |
+| **`nvidia-smi dmon -s u`** | **SM% vs MEM%**；MEM% 接近 SM% = 带宽-bound | 好（硬件计数器） |
+| **`torch.profiler` kernel breakdown** | 哪类 kernel 吃时间 + **每 step kernel 启动数** | 好 |
+| **实测 `torch.compile`** | 融合后提速多少 = 开销可不可修 | 最硬 |
+
+**反面教材（本 sprint 自己踩的坑）**：只用 batch-scaling（sb=1/2/4 吞吐持平）就断言"compute
+到顶"是**错的**——elementwise/launch 开销也随 batch 线性增长，把问题掩盖成平线。必须 profiler
++ compile 实测才看出真相。
+
+## 2. 实测瓶颈（512p/93f/20-step，6 步 profile）
+
+工具：`vrl/scripts/perf/generation_bottleneck_profile.py`（torch.profiler + dmon，复用
+仓库 `gemm_projection_breakdown.py` 的 profiler 模式）。
+
+| 指标 | eager | compiled(default) |
+|---|---|---|
+| wall / step | 2.86s | **1.44s** |
+| **kernel 启动 / step** | **5,122** | **2,832**（-45%） |
+| 设备时间：compute(gemm+flash-attn) | 40.9% | 40.9% |
+| 设备时间：访存(elementwise/copy) | **59.1%** | **13.2%** |
+| `dmon` MEM%（显存控制器） | **~82%** | **~48%** |
+| 稳态 s/video（含 decode） | 57.5s | **34.3s（1.68×）** |
+
+读法：compute（GEMM + flash attention）只占 ~41%，**~59% 耗在带宽受限的小 elementwise
+kernel**；MEM% 82% = HBM 带宽吃紧。compile 把这些 elementwise 融进一个 inductor
+`CompiledFxGraph` 大 kernel → 启动数 -45%、HBM 来回搬运减半（MEM% 82→48）→ 1.68× 提速。
+flash attention（torch SDPA 自带，无需 `flash_attn` 包）本就在用，**不是**瓶颈。
+
+## 3. 落地
+
+1. **rollout 打开 compile**：`model.torch_compile.enable=true`（config 默认 false）。
+   `mode=default` 即可（融合 elementwise）；`max-autotune` 编译极慢且只多调 GEMM（非瓶颈），
+   不值。注意首个 rollout 含一次性编译耗时（~1-2min）；分辨率/帧数固定 → 只编一次，不反复重编。
+   实现已存在：`CosmosPredict25Model.torch_compile_transformer()`（runtime 在
+   `cfg.model.torch_compile.enable` 时调用）。
+2. **吞吐量级**仍需多卡数据并行 rollout（仓库 cross-node 基础设施），compile 提速叠加其上。
+
+## 4. 工具（本 sprint 新增的长期资产）
+
+`vrl/scripts/perf/generation_bottleneck_profile.py`：
+```bash
+python -m vrl.scripts.perf.generation_bottleneck_profile \
+  --config experiment/diffusion/cosmos_predict2_5/online_nft_kling_video_reward \
+  --steps 6 [--compile]      # --compile 量化融合效果
+```
+输出：全 kernel self-time 分桶（gemm/attention/elementwise/copy）+ **每 step 启动数** +
+`dmon` SM%/MEM% + chrome trace。
+
+**已知坑（已修）**：torch.profiler 的 `key_averages()` 同时含 CPU 侧 `aten::` 派发包装和
+底层 device kernel，两者带相同 device 时间——**两个都累加会双计数**（早期版本 total CUDA
+时间 36s > wall 17s 就是这个 bug）。修法：`_is_device_kernel()` 只统计原始 kernel，跳过
+`aten::`/`cuda*`/profiler 标记。compiled 路径下 inductor 的 `## Call CompiledFxGraph`
+包装事件同样会和其内部 kernel 双计数，分桶里它落进 "other"——比较时以 **kernel 启动数、
+elementwise 时间、dmon MEM%、稳态 s/video** 为准，别看 compiled 的设备时间总和。
+
+## 5. 参考
+
+- 工具：`vrl/scripts/perf/generation_bottleneck_profile.py`、复用核心
+  `vrl/scripts/perf/gemm_projection_breakdown.py`
+- compile 入口：`vrl/models/diffusion/cosmos/predict2_5/model.py:245` `torch_compile_transformer`
+- forward 路径：`forward_step`（用 `self.transformer`）→ `vrl/generation/diffusion/executor.py:680` `run_denoise_steps`
+- trace：`outputs/perf/gen_eager.json`、`outputs/perf/gen_compiled.json`（perfetto.dev 打开）
+- 相关：`docs/sprints/info/SPRINT_cosmos_performance.md`、`SPRINT_rollout_performance.md`、
+  `docs/sprints/planned/SPRINT_cosmos_predict25_rl_paper_parity.md`

--- a/vrl/scripts/perf/generation_bottleneck_profile.py
+++ b/vrl/scripts/perf/generation_bottleneck_profile.py
@@ -1,0 +1,194 @@
+"""Generation-forward bottleneck profiler — is it compute- or memory-bound, and which kernels?
+
+WHY: GPU util=100% does NOT prove peak FLOPS — a bandwidth-bound kernel (attention
+materializing an O(n^2) matrix, an oversized elementwise/copy) can pin util at 100%
+while wasting the SMs. ``gemm_projection_breakdown.py`` splits *GEMM* time only; this
+tool profiles the WHOLE denoise forward and answers two questions directly:
+
+  1. Which kernels own the device time? (full top-N by self CUDA time, GEMM + attention
+     + norm + elementwise + copy — so a hidden bandwidth-bound kernel shows up.)
+  2. Is the forward compute- or memory-bound? (nvidia-smi dmon samples SM% vs MEM%
+     hardware counters during the profiled window; MEM% >> SM% == bandwidth-bound.)
+
+HOW: reuses the repo torch.profiler pattern (ProfilerActivity.CUDA + key_averages,
+same as gemm_projection_breakdown / compile_benchmark). Kernels are bucketed by name
+into gemm / attention / norm-elementwise / reduction / copy-memset / other so the
+compute-vs-bandwidth split is legible without Nsight Compute (which isn't installed).
+
+Usage:
+    python -m vrl.scripts.perf.generation_bottleneck_profile \
+        --config experiment/diffusion/cosmos_predict2_5/online_nft_kling_video_reward \
+        --steps 6 --warmup 2 --trace outputs/perf/gen_trace.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import time
+from collections import defaultdict
+
+import torch
+
+from vrl.config.loading import load_config
+from vrl.generation.diffusion.layout import VideoGenerationRequest
+from vrl.math.diffusion.flow_matching import sde_step_with_logprob
+
+# Kernel-name -> bucket. First substring match wins; lowercased CUDA kernel name.
+# gemm/attention are compute-heavy; norm/elementwise/reduction/copy are typically
+# bandwidth-bound. A bandwidth bucket dominating == the "slow 访存 kernel" smell.
+_BUCKETS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("gemm", ("gemm", "cutlass", "sgemm", "ampere", "wgrad", "implicit", "cublas", "matmul")),
+    ("attention", ("flash", "fmha", "attention", "scaled_dot", "mha", "softmax")),
+    ("norm/elementwise", ("norm", "elementwise", "vectorized", "mul", "add", "silu", "gelu", "activation", "scale")),
+    ("reduction", ("reduce", "sum", "mean", "var")),
+    ("copy/memset", ("copy", "memcpy", "memset", "cat", "transpose", "permute", "contiguous")),
+)
+
+
+def _bucket(name: str) -> str:
+    n = name.lower()
+    for label, keys in _BUCKETS:
+        if any(k in n for k in keys):
+            return label
+    return "other"
+
+
+def build_model(cfg, device, dtype):
+    from vrl.models.diffusion.cosmos.predict2_5.runtime import (
+        build_cosmos_predict25_runtime_bundle,
+        extract_cosmos_predict25_runtime_spec,
+    )
+    cfg.model.use_lora = True
+    spec = extract_cosmos_predict25_runtime_spec(cfg, device, dtype)
+    return build_cosmos_predict25_runtime_bundle(spec).model
+
+
+def make_step_fn(model, cfg, device, dtype):
+    s = cfg.sampling
+    enc = model.encode_prompt(["a physical scene, high quality"], None,
+                              guidance_scale=float(s.guidance_scale),
+                              max_sequence_length=int(s.max_sequence_length))
+    req = VideoGenerationRequest(prompt="a physical scene, high quality", negative_prompt=None,
+            width=int(s.width), height=int(s.height), frame_count=int(s.num_frames),
+            num_steps=int(s.num_steps), guidance_scale=float(s.guidance_scale), seed=0,
+            extra={"max_sequence_length": int(s.max_sequence_length)})
+    state = model.prepare_sampling(req, enc)
+
+    def one_step(idx: int):
+        with torch.no_grad(), torch.amp.autocast("cuda", dtype=dtype):
+            out = model.forward_step(state, idx % int(s.num_steps))
+            r = sde_step_with_logprob(state.scheduler, out["noise_pred"].float(),
+                    state.timesteps[idx % int(s.num_steps)].unsqueeze(0), state.latents.float(),
+                    generator=None, deterministic=True, sde_type="cps")
+            state.latents = r.prev_sample
+    return one_step
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser()
+    p.add_argument("--config", required=True)
+    p.add_argument("--steps", type=int, default=6, help="profiled denoise steps")
+    p.add_argument("--warmup", type=int, default=2)
+    p.add_argument("--trace", default="outputs/perf/gen_trace.json")
+    p.add_argument("--device", default="cuda:0")
+    p.add_argument("--compile", action="store_true",
+                   help="torch.compile the transformer before profiling (measures fusion effect)")
+    args = p.parse_args(argv)
+
+    cfg = load_config(args.config)
+    device = torch.device(args.device)
+    dtype = torch.bfloat16
+    print(f"shape {cfg.sampling.width}x{cfg.sampling.height}x{cfg.sampling.num_frames}, "
+          f"{cfg.sampling.num_steps} steps; profiling {args.steps} steps", flush=True)
+
+    model = build_model(cfg, device, dtype)
+    if args.compile:
+        # use the model's own helper so BOTH self.transformer and pipeline.transformer
+        # (forward_step reads self.transformer) point at the compiled module.
+        print("torch.compile(default) the transformer ...", flush=True)
+        model.torch_compile_transformer("default")
+    step_fn = make_step_fn(model, cfg, device, dtype)
+
+    # extra warmup when compiling so the (slow) first compiled call is excluded
+    for i in range(args.warmup + (3 if args.compile else 0)):
+        step_fn(i)
+    torch.cuda.synchronize(device)
+
+    # Sample SM% vs MEM% hardware counters during the profiled window (compute vs bandwidth).
+    dmon = subprocess.Popen(
+        ["nvidia-smi", "dmon", "-s", "u", "-d", "1", "-c", str(max(2, args.steps))],
+        stdout=subprocess.PIPE, text=True)
+
+    t0 = time.time()
+    with torch.profiler.profile(
+        activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA],
+        record_shapes=True,
+    ) as prof:
+        for i in range(args.steps):
+            step_fn(i)
+        torch.cuda.synchronize(device)
+    wall = time.time() - t0
+    dmon_out, _ = dmon.communicate(timeout=30)
+
+    # Per-kernel device self time, bucketed. Count ONLY raw device kernels: skip the
+    # CPU-side ``aten::`` dispatcher wrappers and ``cuda*`` runtime calls, which carry
+    # the SAME device time as the kernel they launch (summing both double-counts —
+    # that earlier made total CUDA time exceed wall time). Profiler markers excluded too.
+    def _is_device_kernel(key: str) -> bool:
+        k = key.strip()
+        if k.startswith("aten::") or k.startswith("cuda") or k.startswith("Command Buffer") \
+                or k.startswith("ProfilerStep") or k.startswith("Memcpy") or k.startswith("Memset"):
+            return key.startswith(("Memcpy", "Memset"))  # keep mem ops, drop aten/cuda/markers
+        return True
+
+    bucket_us: dict[str, float] = defaultdict(float)
+    bucket_calls: dict[str, int] = defaultdict(int)
+    top: list[tuple[float, str]] = []
+    total_cuda_us = 0.0
+    n_launches = 0
+    for evt in prof.key_averages():
+        if not _is_device_kernel(str(evt.key)):
+            continue
+        dev_us = float(getattr(evt, "self_device_time_total", 0) or
+                       getattr(evt, "self_cuda_time_total", 0) or 0)
+        if dev_us <= 0:
+            continue
+        calls = int(getattr(evt, "count", 0) or 0)
+        total_cuda_us += dev_us
+        n_launches += calls
+        b = _bucket(str(evt.key))
+        bucket_us[b] += dev_us
+        bucket_calls[b] += calls
+        top.append((dev_us, str(evt.key)))
+
+    total = total_cuda_us or 1.0
+    print(f"\n=== wall {wall:.1f}s for {args.steps} steps ({wall/args.steps:.2f}s/step), "
+          f"device-kernel time {total/1e6:.2f}s, {n_launches} kernel launches "
+          f"({n_launches/args.steps:.0f}/step) ===")
+    print("\n--- device time by bucket (compute = gemm+attention; bandwidth = norm/copy/reduction) ---")
+    comp = bucket_us.get("gemm", 0) + bucket_us.get("attention", 0)
+    band = bucket_us.get("norm/elementwise", 0) + bucket_us.get("copy/memset", 0) + bucket_us.get("reduction", 0)
+    for b in ("gemm", "attention", "norm/elementwise", "reduction", "copy/memset", "other"):
+        v = bucket_us.get(b, 0.0)
+        if v > 0:
+            print(f"  {b:18s} {v/total*100:5.1f}%  ({v/1e6:.2f}s)")
+    print(f"  → compute(gemm+attn) {comp/total*100:.1f}%  vs  bandwidth(norm/copy/reduce) {band/total*100:.1f}%")
+
+    print("\n--- top 15 kernels by self device time ---")
+    for dev_us, name in sorted(top, reverse=True)[:15]:
+        print(f"  {dev_us/total*100:5.1f}%  {dev_us/1e3:8.1f}ms  [{_bucket(name):16s}] {name[:70]}")
+
+    print("\n--- nvidia-smi dmon (sm% = compute util, mem% = memory-controller util) ---")
+    print("    bandwidth-bound smell: mem% sustained near or above sm%")
+    for line in dmon_out.strip().splitlines()[-(args.steps + 2):]:
+        print("   ", line)
+
+    import os
+    os.makedirs(os.path.dirname(args.trace) or ".", exist_ok=True)
+    prof.export_chrome_trace(args.trace)
+    print(f"\nchrome trace -> {args.trace} (open in chrome://tracing or perfetto.dev)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
…rch.compile = 1.68x

Cosmos Predict2.5 rollout generation (512p/93f/20-step) is NOT compute-bound: each denoise step launches 5,122 kernels, ~57% of device time is small elementwise kernels, and nvidia-smi dmon shows MEM% sustained ~82%. GPU util=100% masks this (util is necessary-not-sufficient). torch.compile(default) fuses the elementwise kernels: launches 5,122->2,832/step (-45%), elementwise 57%->13%, MEM% 82%->48%, 1.68x speedup (57.5->34.3 s/video).

- vrl/scripts/perf/generation_bottleneck_profile.py: torch.profiler + dmon bottleneck tool (full-kernel buckets, per-step launch count, SM%/MEM%, chrome trace, --compile). Fixes double-counting of aten:: dispatcher wrappers vs raw device kernels.
- docs/sprints/info/SPRINT_cosmos_generation_compile_bottleneck.md: methodology (how to tell compute- vs bandwidth-bound), measurements, and the action: enable model.torch_compile.enable=true for rollout.