### PR TITLE
fix(training): enforce replay parity and compose runtime contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, 'review/**']
   schedule:
     - cron: "0 7 * * *"  # nightly: full suite incl. slow_test (Ray) tests
   workflow_dispatch:

--- a/tests/algorithms/test_advantage_combine.py
+++ b/tests/algorithms/test_advantage_combine.py
@@ -1,0 +1,108 @@
+"""Multi-objective advantage combination: per-component normalization must stop
+a high-variance reward from dominating the combined advantage."""
+
+from __future__ import annotations
+
+import torch
+
+from vrl.algorithms.advantages import GroupAdvantageEstimator
+
+_KW = {"eps": 1e-4, "adv_clip_max": 5.0, "global_std": False}
+
+
+def _corr(a: torch.Tensor, b: torch.Tensor) -> float:
+    a = a - a.mean()
+    b = b - b.mean()
+    denom = (a.norm() * b.norm()).item()
+    return float((a @ b).item() / denom) if denom > 1e-9 else 0.0
+
+
+def test_normalized_sum_de_dominates_high_variance_component() -> None:
+    """One group; a low-variance 'quality' reward and a 10x-variance 'nsfw'
+    penalty that ranks samples in the OPPOSITE order, equal weights.
+
+    weighted_sum_raw: the combined advantage tracks nsfw (it dominates by scale).
+    normalized_sum: each component is z-scored first, so nsfw no longer
+    dominates and quality gets equal say — here they cancel to ~0.
+    """
+    group_ids = torch.zeros(4, dtype=torch.long)
+    quality = torch.tensor([1.0, 2.0, 3.0, 4.0])  # increasing, std ~1.1
+    nsfw = torch.tensor([40.0, 30.0, 20.0, 10.0])  # decreasing, std ~11
+    comps = {"quality": quality, "nsfw": nsfw}
+    weights = {"quality": 1.0, "nsfw": 1.0}
+
+    weighted_total = sum(weights[name] * reward for name, reward in comps.items())
+    raw = GroupAdvantageEstimator(
+        strategy="weighted_sum_raw",
+        component_weights=weights,
+        **_KW,
+    ).compute(
+        weighted_total,
+        group_ids,
+        component_rewards=comps,
+    )
+    norm = GroupAdvantageEstimator(
+        strategy="normalized_sum",
+        component_weights=weights,
+        **_KW,
+    ).compute(
+        weighted_total,
+        group_ids,
+        component_rewards=comps,
+    )
+
+    # Raw path is captured by the high-variance nsfw reward (strong +corr).
+    assert _corr(raw, nsfw) > 0.99
+    assert _corr(raw, quality) < -0.99
+    # Normalized path gives the two equal-weight components equal pull, so the
+    # opposite rankings cancel to ~0: nsfw no longer dominates.
+    assert norm.abs().max().item() < 0.1
+    assert norm.abs().max().item() < 0.05 * raw.abs().max().item()
+
+
+def test_normalized_sum_lets_low_variance_component_win_when_weighted() -> None:
+    """With normalization, upweighting quality flips the ranking toward quality —
+    impossible under raw summation where nsfw's scale swamps any sane weight."""
+    group_ids = torch.zeros(4, dtype=torch.long)
+    quality = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    nsfw = torch.tensor([40.0, 30.0, 20.0, 10.0])
+    comps = {"quality": quality, "nsfw": nsfw}
+    weights = {"quality": 2.0, "nsfw": 1.0}
+
+    norm = GroupAdvantageEstimator(
+        strategy="normalized_sum",
+        component_weights=weights,
+        **_KW,
+    ).compute(
+        weights["quality"] * quality + weights["nsfw"] * nsfw,
+        group_ids,
+        component_rewards=comps,
+    )
+    # Quality (increasing) now wins: highest-quality sample gets the top advantage.
+    assert int(norm.argmax().item()) == 3
+    assert _corr(norm, quality) > 0.9
+
+    # Component values are not clipped before weighting; only the combined
+    # advantage is clamped. Pre-clipping this outlier would incorrectly yield 1.25.
+    sparse = torch.tensor([0.0] * 31 + [1.0])
+    final_only = GroupAdvantageEstimator(
+        eps=1e-4,
+        adv_clip_max=2.5,
+        global_std=False,
+        strategy="normalized_sum",
+        component_weights={"quality": 0.5},
+    ).compute(
+        0.5 * sparse,
+        torch.zeros(32, dtype=torch.long),
+        component_rewards={"quality": sparse},
+    )
+    assert final_only.max().item() == 2.5
+
+
+def test_unknown_strategy_raises() -> None:
+    try:
+        GroupAdvantageEstimator(strategy="nope", component_weights={"q": 1.0}, **_KW)
+    except ValueError as exc:
+        assert "unknown advantage_combine strategy" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for unknown strategy")

--- a/tests/algorithms/test_grpo.py
+++ b/tests/algorithms/test_grpo.py
@@ -55,6 +55,24 @@ class TestGRPOSingleSampleNaN:
         assert advantages[0] < 0
         assert advantages[3] > 0
 
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+    @pytest.mark.parametrize("global_std", [False, True])
+    def test_constant_non_binary_reward_returns_exact_zero(
+        self,
+        dtype: torch.dtype,
+        global_std: bool,
+    ) -> None:
+        """A constant decimal reward must not create a rounding-error gradient."""
+
+        grpo = GRPO(GRPOConfig(eps=1e-8, global_std=global_std))
+        rewards = torch.full((8,), 0.9, dtype=dtype)
+        group_ids = torch.zeros(8, dtype=torch.long)
+
+        advantages = grpo.compute_advantages_from_tensors(rewards, group_ids)
+
+        assert torch.isfinite(advantages).all()
+        assert torch.equal(advantages, torch.zeros_like(advantages))
+
 
 class TestGRPOFlowMatchingKL:
     """Groups tests for grpoflow matching KL."""

--- a/tests/config/test_builders.py
+++ b/tests/config/test_builders.py
@@ -127,13 +127,11 @@ def test_reward_runtime_config_normalizes_every_component_and_derives_transport(
             {
                 "reward": {
                     "components": {"remote": 0.0, "local": 1.0},
-                    "kwargs": {
+                    "inference": {
                         "remote": {
-                            "inference": {
-                                "kind": "http",
-                                "endpoint": "http://127.0.0.1:8300",
-                                "expected_model": "remote-model",
-                            },
+                            "kind": "http",
+                            "endpoint": "http://127.0.0.1:8300",
+                            "expected_model": "remote-model",
                         },
                     },
                 },
@@ -151,7 +149,13 @@ def test_reward_runtime_config_normalizes_every_component_and_derives_transport(
             {
                 "reward": {
                     "components": {"remote": 0.0},
-                    "kwargs": {"remote": reward.kwargs["remote"]},
+                    "inference": {
+                        "remote": {
+                            "kind": "http",
+                            "endpoint": "http://127.0.0.1:8300",
+                            "expected_model": "remote-model",
+                        },
+                    },
                 },
             },
         ),

--- a/tests/config/test_load_all_experiments.py
+++ b/tests/config/test_load_all_experiments.py
@@ -703,8 +703,10 @@ def test_wan_droid_fullparam_fsdp_3x_l4_preserves_launch_contract(
     assert cfg.reward.components == {"robotics_video_reward": 1.0}
     reward = cfg.reward.kwargs.robotics_video_reward
     assert reward.score_key == "robotics_blend"
-    assert reward.inference.kind == "http"
-    assert reward.inference.expected_model == "robotics-video-reward-v1"
+    assert cfg.reward.inference.robotics_video_reward.kind == "http"
+    assert cfg.reward.inference.robotics_video_reward.expected_model == (
+        "robotics-video-reward-v1"
+    )
 
 
 def test_wan_droid_fullparam_fsdp_4x_l4_uses_symmetric_reward_handoffs(cuda_devices) -> None:

--- a/tests/config/test_loading_composition.py
+++ b/tests/config/test_loading_composition.py
@@ -1,0 +1,99 @@
+"""Runtime preset composition without model/reward experiment cross-products."""
+
+from pathlib import Path
+
+import pytest
+from omegaconf import OmegaConf
+
+from vrl.config.loading import compose_config, load_config
+
+
+@pytest.fixture
+def config_tree(tmp_path: Path) -> Path:
+    presets = {
+        "neutral.yaml": "trainer:\n  output_dir: ???\n",
+        "legacy.yaml": "defaults:\n  - /reward/base\n",
+        "reward/base.yaml": "reward:\n  transport: base\n  score: 0.1\n",
+        "reward/alternate.yaml": "reward:\n  transport: alternate\n",
+        "reward/policy.yaml": (
+            "defaults:\n  - /reward/base\n  - _self_\nreward:\n  rubric: quality\n  score: 0.2\n"
+        ),
+        "reward/identity.yaml": "reward:\n  judge: pinned\n  score: 0.3\n",
+        "dataset/train.yaml": "data:\n  manifest: train.jsonl\n",
+        "run/local.yaml": "trainer:\n  output_dir: outputs/local\n",
+    }
+    for name, content in presets.items():
+        path = tmp_path / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    return tmp_path
+
+
+def test_runtime_presets_supply_absent_groups_and_required_values(config_tree: Path) -> None:
+    overrides = ["+reward=policy", "+dataset=train", "+run=local"]
+
+    cfg = load_config("neutral", overrides=overrides, root=config_tree)
+
+    assert cfg.reward.transport == "base"
+    assert cfg.reward.rubric == "quality"
+    assert cfg.data.manifest == "train.jsonl"
+    assert cfg.trainer.output_dir == "outputs/local"
+
+
+def test_additive_layers_are_ordered_and_dotlist_values_apply_last(config_tree: Path) -> None:
+    overrides = ["+reward=policy", "+reward=identity"]
+    cfg = compose_config("neutral", overrides=overrides, root=config_tree)
+    assert cfg.reward.score == 0.3
+    assert cfg.reward.rubric == "quality"
+    assert cfg.reward.judge == "pinned"
+
+    reversed_cfg = compose_config("neutral", overrides=list(reversed(overrides)), root=config_tree)
+    assert reversed_cfg.reward.score == 0.2
+
+    scalar_cfg = compose_config(
+        "neutral", overrides=["reward.score=0.9", *overrides], root=config_tree
+    )
+    assert scalar_cfg.reward.score == 0.9
+
+
+def test_additive_preset_inheritance_ignores_legacy_default_replacements(
+    config_tree: Path,
+) -> None:
+    cfg = compose_config(
+        "legacy", overrides=["/reward=alternate", "+reward=policy"], root=config_tree
+    )
+
+    assert cfg.reward.transport == "base"
+    assert cfg.reward.rubric == "quality"
+
+
+def test_missing_values_remain_mandatory_after_additive_composition(config_tree: Path) -> None:
+    cfg = compose_config("neutral", overrides=["+reward=policy"], root=config_tree)
+    assert OmegaConf.missing_keys(cfg) == {"trainer.output_dir"}
+
+    with pytest.raises(ValueError, match=r"trainer\.output_dir"):
+        load_config("neutral", overrides=["+reward=policy"], root=config_tree)
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        "+reward",
+        "+=policy",
+        "+reward=",
+        "++reward=policy",
+        "+/reward=policy",
+        "+reward=/policy",
+        "+reward=../policy",
+        "+reward/../dataset=policy",
+        "+reward=./policy",
+    ],
+)
+def test_invalid_additive_selection_is_rejected(config_tree: Path, override: str) -> None:
+    with pytest.raises(ValueError, match="invalid additive preset override"):
+        compose_config("neutral", overrides=[override], root=config_tree)
+
+
+def test_missing_additive_preset_fails_instead_of_being_ignored(config_tree: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        compose_config("neutral", overrides=["+reward=missing"], root=config_tree)

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -1586,40 +1586,53 @@ def test_non_numeric_reward_weight_raises() -> None:
         RewardConfig.model_validate({"components": {"aesthetic": "heavy"}, "kwargs": {}})
 
 
-def test_reward_http_inference_config_is_validated_inside_open_component_kwargs() -> None:
-    """Transport config stays typed even though reward-specific kwargs are open."""
+def test_reward_http_inference_config_is_typed_beside_open_component_kwargs() -> None:
+    """Transport config is typed even though reward-specific kwargs are open."""
 
     cfg = RewardConfig.model_validate(
         {
             "components": {"videoscore2": 1.0},
-            "kwargs": {
+            "kwargs": {"videoscore2": {"artifact_dir": "/shared/artifacts"}},
+            "inference": {
                 "videoscore2": {
-                    "inference": {
-                        "kind": "http",
-                        "endpoint": "http://reward:8300",
-                        "expected_model": "videoscore2-v1",
-                    },
+                    "kind": "http",
+                    "endpoint": "http://reward:8300",
+                    "expected_model": "videoscore2-v1",
                 },
             },
         },
     )
 
-    assert cfg.kwargs["videoscore2"]["inference"]["kind"] == "http"
+    assert cfg.inference["videoscore2"].kind == "http"
 
 
-def test_reward_http_inference_rejects_unknown_field() -> None:
-    with pytest.raises(ValueError, match=r"unsupported .* keys"):
+def test_reward_inference_rejects_unknown_field() -> None:
+    with pytest.raises(ValueError, match=r"unsupported reward\.inference\..* keys"):
         RewardConfig.model_validate(
             {
                 "components": {"videoscore2": 1.0},
-                "kwargs": {
+                "inference": {
                     "videoscore2": {
-                        "inference": {
-                            "kind": "http",
-                            "endpoint": "http://reward:8300",
-                            "expected_model": "videoscore2-v1",
-                            "service_url": "http://legacy",
-                        },
+                        "kind": "http",
+                        "endpoint": "http://reward:8300",
+                        "expected_model": "videoscore2-v1",
+                        "service_url": "http://legacy",
+                    },
+                },
+            },
+        )
+
+
+def test_reward_inference_rejects_unknown_component() -> None:
+    with pytest.raises(ValueError, match="unknown component"):
+        RewardConfig.model_validate(
+            {
+                "components": {"videoscore2": 1.0},
+                "inference": {
+                    "typo_component": {
+                        "kind": "http",
+                        "endpoint": "http://reward:8300",
+                        "expected_model": "videoscore2-v1",
                     },
                 },
             },

--- a/tests/config/test_unknown_keys.py
+++ b/tests/config/test_unknown_keys.py
@@ -11,6 +11,14 @@ from vrl.config.unknown_keys import find_unknown_keys, require_no_unknown_keys
 from vrl.utils.profiling import TorchProfilerConfig
 
 
+def test_required_blocks_do_not_hide_unknown_keys_during_structural_lint() -> None:
+    cfg = OmegaConf.create({"reward": "???", "data": "???", "unknown_section": "???"})
+
+    assert find_unknown_keys(cfg) == ["unknown_section"]
+    assert OmegaConf.is_missing(cfg, "reward")
+    assert OmegaConf.is_missing(cfg, "data")
+
+
 @dataclasses.dataclass
 class _FixtureNestedConfig:
     enabled: bool = False

--- a/tests/models/families/cosmos/anima/test_forward_step.py
+++ b/tests/models/families/cosmos/anima/test_forward_step.py
@@ -69,5 +69,6 @@ def test_anima_forward_step_uses_const_flow_derivative_contract() -> None:
     assert out["noise_pred_cond"] == torch.ones_like(latents)
     assert out["noise_pred_uncond"] == torch.zeros_like(latents)
     assert out["noise_pred"] == torch.full_like(latents, 2.0)
+    assert model.diffusion_pretraining_prediction(out) is out["noise_pred_cond"]
     assert torch.equal(transformer.calls[0]["hidden_states"], latents)
     assert transformer.calls[0]["timestep"] == torch.tensor([0.7])

--- a/tests/models/families/cosmos/anima/test_latent_codec.py
+++ b/tests/models/families/cosmos/anima/test_latent_codec.py
@@ -1,0 +1,48 @@
+"""CPU contract test for Anima clean-target latent encoding."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+
+from vrl.models.families.cosmos.anima.model import AnimaModel
+
+
+class _IdentityVAE:
+    dtype = torch.float32
+
+    def __init__(self, mean: torch.Tensor, std: torch.Tensor) -> None:
+        self.config = SimpleNamespace(
+            latents_mean=mean.flatten().tolist(),
+            latents_std=std.flatten().tolist(),
+            z_dim=int(mean.shape[1]),
+        )
+
+    def encode(self, video: torch.Tensor) -> SimpleNamespace:
+        return SimpleNamespace(latent_dist=SimpleNamespace(mode=lambda: video))
+
+
+def test_encode_video_to_latents_inverts_anima_decode_normalization() -> None:
+    mean = torch.tensor([0.1, -0.2, 0.3]).view(1, 3, 1, 1, 1)
+    std = torch.tensor([0.5, 2.0, 4.0]).view(1, 3, 1, 1, 1)
+    scheduler = SimpleNamespace(config=SimpleNamespace(sigma_data=1.0))
+    model = AnimaModel(
+        transformer=nn.Identity(),
+        text_encoder=None,
+        llm_adapter=nn.Identity(),
+        vae=_IdentityVAE(mean, std),
+        scheduler=scheduler,
+        image_processor=None,
+        qwen_tokenizer=None,
+        t5_tokenizer=None,
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+    )
+    image = torch.rand(2, 3, 1, 4, 4)
+
+    latents = model.encode_video_to_latents(image)
+
+    reconstructed_vae_input = latents * std + mean
+    torch.testing.assert_close(reconstructed_vae_input, image * 2.0 - 1.0)

--- a/tests/ray/test_resources.py
+++ b/tests/ray/test_resources.py
@@ -21,6 +21,7 @@ def _cfg(
     kling_video_reward: bool = False,
     reward_components: dict[str, float] | None = None,
     reward_kwargs: dict[str, dict] | None = None,
+    reward_inference: dict[str, dict] | None = None,
 ) -> object:
     if rollout_runtime is None:
         rollout_runtime = {}
@@ -37,6 +38,7 @@ def _cfg(
         data["reward"] = {
             "components": reward_components,
             "kwargs": reward_kwargs or {},
+            "inference": reward_inference or {},
         }
     return OmegaConf.create(
         data,
@@ -785,13 +787,11 @@ def test_http_only_reward_owns_no_local_resource_or_handoff() -> None:
                 "reward": {"device": "gpu", "devices": [2]},
             },
             reward_components={"videoscore2": 1.0},
-            reward_kwargs={
+            reward_inference={
                 "videoscore2": {
-                    "inference": {
-                        "kind": "http",
-                        "endpoint": "http://reward:8300",
-                        "expected_model": "videoscore2-v1",
-                    },
+                    "kind": "http",
+                    "endpoint": "http://reward:8300",
+                    "expected_model": "videoscore2-v1",
                 },
             },
         ),
@@ -816,13 +816,11 @@ def test_mixed_http_and_local_reward_resources_cover_only_local_execution() -> N
                 "reward": {"device": "cpu"},
             },
             reward_components={"ocr": 0.5, "videoscore2": 0.5},
-            reward_kwargs={
+            reward_inference={
                 "videoscore2": {
-                    "inference": {
-                        "kind": "http",
-                        "endpoint": "http://reward:8300",
-                        "expected_model": "videoscore2-v1",
-                    },
+                    "kind": "http",
+                    "endpoint": "http://reward:8300",
+                    "expected_model": "videoscore2-v1",
                 },
             },
         ),

--- a/tests/rewards/functions/test_multi.py
+++ b/tests/rewards/functions/test_multi.py
@@ -439,15 +439,13 @@ def test_http_disk_reward_builds_transport_without_local_model_config(tmp_path) 
     reward = MultiReward.from_dict(
         {"videoscore2": 1.0},
         device="cuda:0",
-        reward_kwargs={
-            "videoscore2": {
-                "artifact_dir": str(tmp_path),
-                "inference": {
-                    "kind": "http",
-                    "endpoint": "http://reward:8300",
-                    "expected_model": "videoscore2-v1",
-                },
-            },
+        reward_kwargs={"videoscore2": {"artifact_dir": str(tmp_path)}},
+        inference_configs={
+            "videoscore2": RewardInferenceConfig(
+                kind="http",
+                endpoint="http://reward:8300",
+                expected_model="videoscore2-v1",
+            ),
         },
         memory_parking_required=False,
     )
@@ -466,14 +464,12 @@ def test_http_reward_rejects_inmemory_artifact_component() -> None:
         MultiReward.from_dict(
             {"aesthetic": 1.0},
             device="cpu",
-            reward_kwargs={
-                "aesthetic": {
-                    "inference": {
-                        "kind": "http",
-                        "endpoint": "http://reward:8300",
-                        "expected_model": "aesthetic-v1",
-                    },
-                },
+            inference_configs={
+                "aesthetic": RewardInferenceConfig(
+                    kind="http",
+                    endpoint="http://reward:8300",
+                    expected_model="aesthetic-v1",
+                ),
             },
         )
 
@@ -592,15 +588,14 @@ def test_mixed_runtime_components_fail_closed_for_generation_overlap(tmp_path) -
     reward = MultiReward.from_dict(
         {"videoscore2": 1.0, "ocr": 0.5},
         device="cpu",
-        reward_kwargs={
-            "videoscore2": {
-                "artifact_dir": str(tmp_path),
-                "inference": {
-                    "kind": "http",
-                    "endpoint": "http://reward:8300",
-                    "expected_model": "videoscore2-v1",
-                },
-            },
+        reward_kwargs={"videoscore2": {"artifact_dir": str(tmp_path)}},
+        inference_configs={
+            "videoscore2": RewardInferenceConfig(
+                kind="http",
+                endpoint="http://reward:8300",
+                expected_model="videoscore2-v1",
+            ),
+            "ocr": RewardInferenceConfig(),
         },
     )
 
@@ -615,12 +610,14 @@ def test_http_reward_rejects_local_worker_config() -> None:
             device="cpu",
             reward_kwargs={
                 "videoscore2": {
-                    "inference": {
-                        "kind": "http",
-                        "endpoint": "http://reward:8300",
-                        "expected_model": "videoscore2-v1",
-                    },
                     "worker_config": {"device": "cuda:0"},
                 },
+            },
+            inference_configs={
+                "videoscore2": RewardInferenceConfig(
+                    kind="http",
+                    endpoint="http://reward:8300",
+                    expected_model="videoscore2-v1",
+                ),
             },
         )

--- a/tests/rewards/inference/test_artifact_store.py
+++ b/tests/rewards/inference/test_artifact_store.py
@@ -37,6 +37,7 @@ def test_video_artifact_store_writes_tensor_with_provenance(tmp_path: Path) -> N
     assert len(artifacts) == 1
     artifact = artifacts[0]
     assert artifact.artifact_id.startswith("sample-x:")
+    assert artifact.sample_id == "sample-x"
     assert Path(artifact.path).is_absolute()
     assert Path(artifact.path).exists()
     assert artifact.size_bytes == Path(artifact.path).stat().st_size

--- a/tests/rewards/inference/test_in_process_runtime.py
+++ b/tests/rewards/inference/test_in_process_runtime.py
@@ -29,11 +29,13 @@ def _make_request() -> RewardInferenceRequest:
         artifacts=(
             RewardInferenceArtifact(
                 artifact_id="a",
+                sample_id="sample-a",
                 path="",
                 media=[1.0, 2.0],
             ),
             RewardInferenceArtifact(
                 artifact_id="b",
+                sample_id="sample-b",
                 path="",
                 media=[3.0],
             ),
@@ -181,6 +183,7 @@ def _parking_request() -> RewardInferenceRequest:
         artifacts=(
             RewardInferenceArtifact(
                 artifact_id="a0",
+                sample_id="sample-0",
                 path="/tmp/a0.mp4",
                 prompt="p",
             ),
@@ -456,6 +459,7 @@ async def test_real_aesthetic_score_parks_stably_across_two_cycles() -> None:
         artifacts=(
             RewardInferenceArtifact(
                 artifact_id="image-0",
+                sample_id="sample-0",
                 path="",
                 media=torch.zeros(3, 512, 512),
             ),

--- a/tests/rewards/inference/test_runtime_factory.py
+++ b/tests/rewards/inference/test_runtime_factory.py
@@ -40,7 +40,13 @@ def test_runtime_requires_model_factory() -> None:
     )
     request = RewardInferenceRequest(
         request_id="req",
-        artifacts=(RewardInferenceArtifact(artifact_id="a0", path="/tmp/a0.mp4"),),
+        artifacts=(
+            RewardInferenceArtifact(
+                artifact_id="a0",
+                sample_id="sample-0",
+                path="/tmp/a0.mp4",
+            ),
+        ),
     )
     with pytest.raises(ValueError, match="model_factory"):
         asyncio.run(runtime.score_batch(request))
@@ -105,6 +111,7 @@ async def test_runtime_loads_reward_model_via_factory() -> None:
         artifacts=(
             RewardInferenceArtifact(
                 artifact_id="a0",
+                sample_id="sample-0",
                 path="/tmp/a0.mp4",
                 prompt="prompt",
             ),

--- a/tests/rewards/inference/test_schema.py
+++ b/tests/rewards/inference/test_schema.py
@@ -14,6 +14,7 @@ from vrl.rewards.inference import (
 def _artifact(artifact_id: str) -> RewardInferenceArtifact:
     return RewardInferenceArtifact(
         artifact_id=artifact_id,
+        sample_id=f"sample-{artifact_id}",
         path=f"/tmp/{artifact_id}.pt",
         prompt="prompt",
     )
@@ -23,6 +24,17 @@ def test_request_rejects_duplicate_artifact_ids() -> None:
     artifact = _artifact("x")
     with pytest.raises(ValueError, match="duplicate"):
         RewardInferenceRequest(request_id="req", artifacts=(artifact, artifact))
+
+
+@pytest.mark.parametrize("sample_id", ["", None])
+def test_artifact_requires_typed_sample_id(sample_id: object) -> None:
+    expected = "must be non-empty" if sample_id == "" else "must be a str"
+    with pytest.raises((TypeError, ValueError), match=expected):
+        RewardInferenceArtifact(
+            artifact_id="artifact",
+            sample_id=sample_id,  # type: ignore[arg-type]
+            path="/tmp/artifact.pt",
+        )
 
 
 @pytest.mark.parametrize(
@@ -42,6 +54,7 @@ def test_artifact_rejects_invalid_file_integrity(
     with pytest.raises(ValueError, match=message):
         RewardInferenceArtifact(
             artifact_id="artifact",
+            sample_id="sample-0",
             path="/tmp/artifact.pt",
             size_bytes=size_bytes,
             sha256=sha256,
@@ -52,6 +65,7 @@ def test_inmemory_artifact_rejects_file_integrity() -> None:
     with pytest.raises(ValueError, match="in-memory media cannot declare"):
         RewardInferenceArtifact(
             artifact_id="artifact",
+            sample_id="sample-0",
             path="",
             media=object(),
             size_bytes=1,

--- a/tests/rewards/kling_video_reward/test_model_loading.py
+++ b/tests/rewards/kling_video_reward/test_model_loading.py
@@ -58,6 +58,7 @@ def test_kling_video_reward_requires_materialized_artifact_path() -> None:
     model.use_norm = True
     artifact = RewardInferenceArtifact(
         artifact_id="a0",
+        sample_id="sample-0",
         path="",
         media=object(),
         prompt="prompt",

--- a/tests/rewards/phymotion/test_phymotion.py
+++ b/tests/rewards/phymotion/test_phymotion.py
@@ -65,6 +65,7 @@ def test_full_call_runs_external_command(tmp_path: Path) -> None:
     )
     artifact = RewardInferenceArtifact(
         artifact_id="clip",
+        sample_id="sample-clip",
         path=str(video),
         prompt="dance",
     )

--- a/tests/rewards/service/test_service.py
+++ b/tests/rewards/service/test_service.py
@@ -49,6 +49,7 @@ def _request(
         artifacts=(
             RewardInferenceArtifact(
                 artifact_id="a0",
+                sample_id="sample-0",
                 path=path,
                 prompt=prompt,
                 size_bytes=len(payload),
@@ -109,6 +110,7 @@ async def _running_service(
             endpoint=f"http://{host}:{port}",
             timeout_s=5,
             expected_model="unit-model",
+            expected_model_version="unit-v1",
         ),
     )
     try:
@@ -132,6 +134,7 @@ def test_wire_roundtrip_is_versioned_and_preserves_request(tmp_path) -> None:
     assert restored.artifacts[0].path == str(artifact_file)
     assert restored.artifacts[0].size_bytes == 1
     assert restored.artifacts[0].sha256 == hashlib.sha256(b"x").hexdigest()
+    assert restored.artifacts[0].sample_id == "sample-0"
     assert restored.artifacts[0].metadata == {"target_text": "HELLO"}
 
 
@@ -141,6 +144,7 @@ def test_wire_rejects_inmemory_media() -> None:
         artifacts=(
             RewardInferenceArtifact(
                 artifact_id="a0",
+                sample_id="sample-0",
                 path="",
                 media=object(),
             ),
@@ -291,7 +295,19 @@ async def test_client_verifies_isolation_only_after_safe_service_preflight(tmp_p
 
 
 @pytest.mark.asyncio
-async def test_expected_model_mismatch_fails_before_scoring(tmp_path) -> None:
+@pytest.mark.parametrize(
+    ("expected_model", "expected_version", "message"),
+    [
+        ("wrong-model", "", "identity mismatch"),
+        ("actual-model", "wrong-version", "version mismatch"),
+    ],
+)
+async def test_expected_model_identity_mismatch_fails_before_scoring(
+    tmp_path,
+    expected_model: str,
+    expected_version: str,
+    message: str,
+) -> None:
     artifact_file = tmp_path / "a0.mp4"
     artifact_file.write_bytes(b"x")
     runtime = _FakeRuntime()
@@ -301,6 +317,7 @@ async def test_expected_model_mismatch_fails_before_scoring(tmp_path) -> None:
         host="127.0.0.1",
         port=0,
         model_name="actual-model",
+        model_version="actual-version",
     )
     await service.start()
     host, port = service.address
@@ -308,11 +325,12 @@ async def test_expected_model_mismatch_fails_before_scoring(tmp_path) -> None:
         RewardInferenceConfig(
             kind="http",
             endpoint=f"http://{host}:{port}",
-            expected_model="wrong-model",
+            expected_model=expected_model,
+            expected_model_version=expected_version,
         ),
     )
     try:
-        with pytest.raises(RemoteRewardServiceError, match="identity mismatch") as caught:
+        with pytest.raises(RemoteRewardServiceError, match=message) as caught:
             await client.score_batch(_request(str(artifact_file)))
     finally:
         await client.shutdown()

--- a/tests/rewards/test_config.py
+++ b/tests/rewards/test_config.py
@@ -12,7 +12,7 @@ from vrl.config.reward_inference import (
 
 
 def test_in_process_is_the_default() -> None:
-    assert parse_reward_inference_config(None, context="reward.kwargs.x.inference") == (
+    assert parse_reward_inference_config(None, context="reward.inference.x") == (
         RewardInferenceConfig()
     )
 
@@ -21,12 +21,12 @@ def test_http_requires_endpoint_and_expected_model() -> None:
     with pytest.raises(ValueError, match="absolute http"):
         parse_reward_inference_config(
             {"kind": "http", "expected_model": "judge-v1"},
-            context="reward.kwargs.x.inference",
+            context="reward.inference.x",
         )
     with pytest.raises(ValueError, match="expected_model"):
         parse_reward_inference_config(
             {"kind": "http", "endpoint": "http://reward:8300"},
-            context="reward.kwargs.x.inference",
+            context="reward.inference.x",
         )
 
 
@@ -49,7 +49,7 @@ def test_http_endpoint_is_an_origin_without_embedded_credentials(
                 "endpoint": endpoint,
                 "expected_model": "unit",
             },
-            context="reward.kwargs.x.inference",
+            context="reward.inference.x",
         )
 
 
@@ -57,7 +57,7 @@ def test_unknown_inference_key_is_rejected_from_typed_source() -> None:
     with pytest.raises(ValueError, match=r"unsupported .* keys"):
         parse_reward_inference_config(
             {"kind": "in_process", "service_url": "http://legacy"},
-            context="reward.kwargs.x.inference",
+            context="reward.inference.x",
         )
 
 
@@ -65,14 +65,13 @@ def test_component_inference_configs_resolve_independently() -> None:
     cfg = {
         "reward": {
             "components": {"ocr": 0.25, "videoscore2": 0.75},
-            "kwargs": {
+            "inference": {
                 "videoscore2": {
-                    "inference": {
-                        "kind": "http",
-                        "endpoint": "http://reward:8300",
-                        "timeout_s": 90,
-                        "expected_model": "videoscore2-v1",
-                    },
+                    "kind": "http",
+                    "endpoint": "http://reward:8300",
+                    "timeout_s": 90,
+                    "expected_model": "videoscore2-v1",
+                    "expected_model_version": "VideoScore2@unit-revision",
                 },
             },
         },
@@ -86,4 +85,5 @@ def test_component_inference_configs_resolve_independently() -> None:
         endpoint="http://reward:8300",
         timeout_s=90,
         expected_model="videoscore2-v1",
+        expected_model_version="VideoScore2@unit-revision",
     )

--- a/tests/rewards/test_decode_artifact_frames.py
+++ b/tests/rewards/test_decode_artifact_frames.py
@@ -17,6 +17,7 @@ def test_inline_uint8_video_reaches_reward_as_original_normalized_pixels() -> No
     )
     artifact = RewardInferenceArtifact(
         artifact_id="inline-uint8-video",
+        sample_id="sample-inline-uint8-video",
         path="",
         media=video,
     )

--- a/tests/rewards/test_robotics_video_reward.py
+++ b/tests/rewards/test_robotics_video_reward.py
@@ -76,6 +76,7 @@ def test_robotics_reward_uses_only_audited_kling_alignment(
     )
     artifact = RewardInferenceArtifact(
         artifact_id="a0",
+        sample_id="sample-0",
         path=str(tmp_path / "a0.mp4"),
         prompt="Move the object into the tray",
         metadata={"target_video": "targets/a0.mp4"},

--- a/tests/rollouts/collector/test_runtime.py
+++ b/tests/rollouts/collector/test_runtime.py
@@ -662,6 +662,10 @@ def test_reward_samples_preserve_prompt_identity_and_metadata() -> None:
         "request-0:sample:1",
     ]
     assert all(sample.metadata["target_text"] == "caption" for sample in samples)
+    assert [sample.metadata["reward_group_id"] for sample in samples] == [
+        "request-0:prompt:0",
+        "request-0:prompt:1",
+    ]
     assert not any(
         hasattr(sample, name)
         for sample in samples
@@ -681,13 +685,13 @@ def test_collector_uses_one_reward_call_and_splits_scores_per_group() -> None:
 
     async def _collect_groups():
         first = await collector.collect_unscored(
-            ["g0"],
+            ["same prompt"],
             group_size=2,
             metadata={"target_text": "group-0"},
             policy_version=4,
         )
         second = await collector.collect_unscored(
-            ["g1"],
+            ["same prompt"],
             group_size=3,
             metadata={"target_text": "group-1"},
             policy_version=5,
@@ -698,7 +702,7 @@ def test_collector_uses_one_reward_call_and_splits_scores_per_group() -> None:
 
     assert len(reward_runtime.calls) == 1
     call = reward_runtime.calls[0]
-    assert call["prompts"] == ["g0", "g0", "g1", "g1", "g1"]
+    assert call["prompts"] == ["same prompt"] * 5
     assert [metadata["target_text"] for metadata in call["metadata"]] == [
         "group-0",
         "group-0",
@@ -707,6 +711,11 @@ def test_collector_uses_one_reward_call_and_splits_scores_per_group() -> None:
         "group-1",
     ]
     assert len(set(call["sample_ids"])) == 5
+    reward_group_ids = [metadata["reward_group_id"] for metadata in call["metadata"]]
+    assert len(set(reward_group_ids[:2])) == 1
+    assert len(set(reward_group_ids[2:])) == 1
+    assert reward_group_ids[0] != reward_group_ids[2]
+    assert all(group_id.endswith(":prompt:0") for group_id in reward_group_ids)
     assert first.rewards.tolist() == [0.0, 1.0]
     assert second.rewards.tolist() == [2.0, 3.0, 4.0]
 

--- a/tests/scripts/eval/test_sana_aesthetic_checkpoint_eval.py
+++ b/tests/scripts/eval/test_sana_aesthetic_checkpoint_eval.py
@@ -516,6 +516,27 @@ def test_historical_fullparam_shape_normalizes_to_the_live_protocol() -> None:
     )
 
 
+def test_historical_parity_threshold_normalizes_without_changing_frozen_identity() -> None:
+    canonical = load_config(sana_report.CANONICAL_CONFIG_NAME)
+    historical = OmegaConf.to_container(canonical, resolve=True)
+    historical["trainer"]["debug"].update(historical["trainer"].pop("replay_parity"))
+
+    assert sana_report._semantic_digest(historical) == sana_report.CANONICAL_PROTOCOL_SHA256
+    normalized = sana_report.normalize_run_config(OmegaConf.create(historical))
+    assert OmegaConf.to_container(normalized, resolve=True) == OmegaConf.to_container(
+        canonical, resolve=True
+    )
+
+
+@pytest.mark.parametrize("old_threshold", [1.0e-6, 1.0e-4])
+def test_parity_threshold_rejects_ambiguous_old_and_live_keys(old_threshold) -> None:
+    changed = load_config(sana_report.CANONICAL_CONFIG_NAME)
+    changed.trainer.debug.max_abs_logprob_diff = old_threshold
+
+    with pytest.raises(ValueError, match="ambiguous SANA parity threshold"):
+        sana_report.normalize_run_config(changed)
+
+
 @pytest.mark.parametrize(
     ("path", "value"),
     [
@@ -674,6 +695,7 @@ def test_live_entrypoint_requires_explicit_precision_protocol(path: str) -> None
         ("actor.ppo_epochs", 4),
         ("trainer.total_epochs", 301),
         ("sampling.num_steps", 11),
+        ("trainer.replay_parity.max_abs_logprob_diff", 1.0e-4),
     ],
 )
 def test_fullparam_protocol_rejects_scientific_drift(path: str, value: object) -> None:
@@ -700,7 +722,15 @@ def test_quality_sampling_is_official_and_not_derived_from_training_sde() -> Non
     }
 
 
-def test_canonical_preset_change_requires_protocol_digest_update(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        ("sampling.num_steps", 11),
+        ("trainer.replay_parity.max_abs_logprob_diff", 1.0e-4),
+        ("trainer.replay_parity.unexpected", True),
+    ],
+)
+def test_canonical_preset_change_requires_protocol_digest_update(monkeypatch, path, value) -> None:
     actual = load_config(sana_report.CANONICAL_CONFIG_NAME)
     real_load_config = sana_report.load_config
 
@@ -708,7 +738,7 @@ def test_canonical_preset_change_requires_protocol_digest_update(monkeypatch) ->
         cfg = real_load_config(name, *args, **kwargs)
         if str(name) == sana_report.CANONICAL_CONFIG_NAME:
             cfg = OmegaConf.create(OmegaConf.to_container(cfg, resolve=True))
-            cfg.sampling.num_steps = 11
+            OmegaConf.update(cfg, path, value, merge=False)
         return cfg
 
     monkeypatch.setattr(sana_report, "load_config", changed_canonical)

--- a/tests/scripts/eval/test_wan_hpsv3_checkpoint_eval.py
+++ b/tests/scripts/eval/test_wan_hpsv3_checkpoint_eval.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from omegaconf import OmegaConf
+
+from vrl.scripts.eval import _score_summary
+from vrl.scripts.eval import wan_hpsv3_checkpoint_eval as checkpoint_eval
+
+
+def _score_row(label: str, prompt: int, sample: int, value: float) -> dict[str, object]:
+    return {
+        "checkpoint_label": label,
+        "prompt_index": prompt,
+        "sample_index": sample,
+        "r_top_frame_mean": value,
+        "r_frame_mean": value - 0.5,
+        "r_frame_min": value - 1.0,
+    }
+
+
+def _grid(label: str, values: list[float]) -> list[dict[str, object]]:
+    return [_score_row(label, index // 2, index % 2, value) for index, value in enumerate(values)]
+
+
+# --- paired summary ----------------------------------------------------------
+
+
+def test_paired_delta_detects_improvement_and_regression() -> None:
+    rows = [
+        *_grid("base", [1.0, 2.0, 3.0, 4.0]),
+        *_grid("better", [2.0, 3.0, 4.0, 5.0]),
+        *_grid("worse", [0.0, 1.0, 2.0, 3.0]),
+    ]
+
+    summary = _score_summary.summarize_paired_scores(
+        rows,
+        score_keys=checkpoint_eval.SCORE_KEYS,
+        schema=checkpoint_eval.REPORT_SCHEMA,
+    )
+
+    better = summary["paired_delta_from_base"]["better"]["top_frame_mean"]
+    worse = summary["paired_delta_from_base"]["worse"]["top_frame_mean"]
+    assert better["mean"] == pytest.approx(1.0)
+    assert better["win_rate"] == 1.0
+    assert better["clear_improvement"] is True
+    assert better["clear_regression"] is False
+    assert worse["mean"] == pytest.approx(-1.0)
+    assert worse["clear_regression"] is True
+    assert summary["absolute"]["base"]["top_frame_mean"]["mean"] == pytest.approx(2.5)
+
+
+def test_paired_summary_reports_every_score_key() -> None:
+    """frame_mean/frame_min ride along so reward hacking stays visible."""
+
+    rows = [*_grid("base", [1.0, 2.0]), *_grid("later", [3.0, 4.0])]
+
+    summary = _score_summary.summarize_paired_scores(
+        rows,
+        score_keys=checkpoint_eval.SCORE_KEYS,
+        schema=checkpoint_eval.REPORT_SCHEMA,
+    )
+
+    assert set(summary["paired_delta_from_base"]["later"]) == set(checkpoint_eval.SCORE_KEYS)
+
+
+def test_paired_summary_refuses_a_mismatched_grid() -> None:
+    rows = [*_grid("base", [1.0, 2.0]), *_grid("short", [1.0])]
+
+    with pytest.raises(ValueError, match="paired score grid differs"):
+        _score_summary.summarize_paired_scores(
+            rows,
+            score_keys=("top_frame_mean",),
+            schema=checkpoint_eval.REPORT_SCHEMA,
+        )
+
+
+def test_paired_summary_requires_the_base_arm() -> None:
+    with pytest.raises(ValueError, match="requires 'base' rows"):
+        _score_summary.summarize_paired_scores(
+            _grid("only", [1.0, 2.0]),
+            score_keys=("top_frame_mean",),
+            schema=checkpoint_eval.REPORT_SCHEMA,
+        )
+
+
+def test_bootstrap_interval_is_deterministic_and_brackets_the_mean() -> None:
+    values = [0.1, 0.4, -0.2, 0.9, 0.3, 0.5]
+    first = _score_summary.bootstrap_mean_interval(
+        values,
+        schema="s",
+        label="ckpt",
+        score_key="top_frame_mean",
+    )
+    second = _score_summary.bootstrap_mean_interval(
+        values,
+        schema="s",
+        label="ckpt",
+        score_key="top_frame_mean",
+    )
+
+    assert first == second
+    assert first[0] < sum(values) / len(values) < first[1]
+
+
+def test_write_scores_publishes_jsonl_and_csv(tmp_path: Path) -> None:
+    rows = _grid("base", [1.0, 2.0])
+
+    _score_summary.write_scores(rows, tmp_path)
+
+    written = [json.loads(line) for line in (tmp_path / "scores.jsonl").read_text().splitlines()]
+    assert written == rows
+    assert "r_top_frame_mean" in (tmp_path / "scores.csv").read_text().splitlines()[0]
+
+
+# --- checkpoint targets ------------------------------------------------------
+
+
+def test_target_label_defaults_to_the_directory_name(tmp_path: Path) -> None:
+    path = tmp_path / "checkpoint-12"
+    path.mkdir()
+
+    assert checkpoint_eval._parse_targets([str(path)]) == [
+        checkpoint_eval.CheckpointTarget(label="checkpoint-12", path=path.resolve()),
+    ]
+
+
+def test_explicit_label_overrides_the_directory_name(tmp_path: Path) -> None:
+    path = tmp_path / "checkpoint-12"
+    path.mkdir()
+
+    (target,) = checkpoint_eval._parse_targets([f"late={path}"])
+
+    assert target.label == "late"
+
+
+def test_base_label_is_reserved_for_the_adapter_disabled_arm(tmp_path: Path) -> None:
+    path = tmp_path / "checkpoint-2"
+    path.mkdir()
+
+    with pytest.raises(ValueError, match="reserved"):
+        checkpoint_eval._parse_targets([f"base={path}"])
+
+
+def test_duplicate_labels_are_refused(tmp_path: Path) -> None:
+    first = tmp_path / "a" / "checkpoint-2"
+    second = tmp_path / "b" / "checkpoint-2"
+    first.mkdir(parents=True)
+    second.mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="must be unique"):
+        checkpoint_eval._parse_targets([str(first), str(second)])
+
+
+def test_missing_checkpoint_path_is_refused(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        checkpoint_eval._parse_targets([str(tmp_path / "absent")])
+
+
+# --- run config --------------------------------------------------------------
+
+
+def _write_run(tmp_path: Path, **model_overrides: object) -> Path:
+    model = {
+        "family": "wan",
+        "path": "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+        "use_lora": True,
+        "lora": {
+            "rank": 32,
+            "alpha": 64,
+            "target_modules": ["to_q"],
+            "path": "donor/lora_weights",
+        },
+        "torch_compile": {"enable": True},
+        **model_overrides,
+    }
+    OmegaConf.save(OmegaConf.create({"model": model}), tmp_path / "resolved_config.yaml")
+    return tmp_path
+
+
+def test_run_config_clears_the_warm_start_adapter_and_compile(tmp_path: Path) -> None:
+    """A warm-started run records its donor adapter; the base arm must not inherit it."""
+
+    cfg = checkpoint_eval._load_run_config(_write_run(tmp_path))
+
+    assert OmegaConf.select(cfg, "model.lora.path") is None
+    assert OmegaConf.select(cfg, "model.torch_compile.enable") is False
+    assert OmegaConf.select(cfg, "model.use_lora") is True
+
+
+def test_run_config_refuses_another_family(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="requires a wan_2_1 run"):
+        checkpoint_eval._load_run_config(_write_run(tmp_path, family="sana"))
+
+
+def test_run_config_requires_a_resolved_config(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match=r"resolved_config\.yaml"):
+        checkpoint_eval._load_run_config(tmp_path)
+
+
+# --- reward worker config ----------------------------------------------------
+
+
+def test_worker_config_projects_the_runs_own_reward_block() -> None:
+    import torch
+
+    cfg = OmegaConf.create(
+        {
+            "reward": {
+                "kwargs": {
+                    "hpsv3": {
+                        "reward_name": "MizzenAI/HPSv3@main",
+                        "worker_config": {"model_path": "/models/HPSv3", "dtype": "bfloat16"},
+                    },
+                },
+            },
+        },
+    )
+
+    worker_config = checkpoint_eval._hpsv3_worker_config(cfg, device=torch.device("cuda:1"))
+
+    assert worker_config["model_path"] == "/models/HPSv3"
+    assert worker_config["dtype"] == "bfloat16"
+    assert worker_config["reward_model_name"] == "MizzenAI/HPSv3@main"
+    assert worker_config["device"] == "cuda:1"

--- a/tests/scripts/test_common_factory.py
+++ b/tests/scripts/test_common_factory.py
@@ -34,11 +34,18 @@ from vrl.scripts.common.factory import (
 def _built_reward(
     weights: dict[str, float],
     kwargs: dict[str, dict],
+    inference: dict[str, dict] | None = None,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         reward=RewardRuntimeConfig.from_cfg(
             OmegaConf.create(
-                {"reward": {"components": weights, "kwargs": kwargs}},
+                {
+                    "reward": {
+                        "components": weights,
+                        "kwargs": kwargs,
+                        "inference": inference or {},
+                    },
+                },
             ),
         ),
     )
@@ -54,10 +61,11 @@ def test_diffusion_grpo_evaluator_uses_resolved_rollout_sde_config() -> None:
         ],
     )
     collector_config = RolloutCollectorConfig.from_cfg(cfg)
+    built = build_configs(cfg)
 
     pair = build_algorithm_and_evaluator(
         family_entry=get_model_family_entry("wan_2_1"),
-        built=build_configs(cfg),
+        built=built,
         collector_config=collector_config,
         scheduler=object(),
     )
@@ -65,6 +73,7 @@ def test_diffusion_grpo_evaluator_uses_resolved_rollout_sde_config() -> None:
     assert pair.evaluator.noise_level == 0.37
     assert pair.evaluator.sde_type == "cps"
     assert collector_config.request_sampling["denoise_mode"] == "native"
+    assert pair.algorithm.advantage_estimator.component_weights == built.reward.weights
 
 
 @pytest.mark.parametrize(
@@ -333,7 +342,7 @@ def test_sana_fullparam_pilot_disables_tf32_and_gates_backend_drift() -> None:
     assert run.total_epochs == 5
     assert run.save_freq == 1
     assert trainer.debug.first_step is True
-    assert trainer.debug.max_abs_logprob_diff == pytest.approx(1.0e-6)
+    assert trainer.replay_parity.max_abs_logprob_diff == pytest.approx(1.0e-6)
     assert trainer.precision_drift_guard.mode == "fail"
     assert trainer.precision_drift_guard.max_abs_log_ratio == pytest.approx(1.0e-6)
     assert trainer.precision_drift_guard.max_ratio_abs_dev == pytest.approx(1.0e-6)
@@ -534,13 +543,11 @@ def test_http_reward_accepts_torchrun_rank_local_device(monkeypatch) -> None:
             },
             "reward": {
                 "components": {"unified_reward_video": 1.0},
-                "kwargs": {
+                "inference": {
                     "unified_reward_video": {
-                        "inference": {
-                            "kind": "http",
-                            "endpoint": "http://127.0.0.1:8300",
-                            "expected_model": "unified-reward-robotics",
-                        },
+                        "kind": "http",
+                        "endpoint": "http://127.0.0.1:8300",
+                        "expected_model": "unified-reward-robotics",
                     },
                 },
             },
@@ -551,13 +558,12 @@ def test_http_reward_accepts_torchrun_rank_local_device(monkeypatch) -> None:
         resolve_reward_inputs(
             _built_reward(
                 {"unified_reward_video": 1.0},
+                {},
                 {
                     "unified_reward_video": {
-                        "inference": {
-                            "kind": "http",
-                            "endpoint": "http://127.0.0.1:8300",
-                            "expected_model": "unified-reward-robotics",
-                        },
+                        "kind": "http",
+                        "endpoint": "http://127.0.0.1:8300",
+                        "expected_model": "unified-reward-robotics",
                     },
                 },
             ),
@@ -629,19 +635,26 @@ def test_shared_reward_capability_fails_before_component_construction(monkeypatc
 def test_shared_reward_preflight_consumes_resolved_inference(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Config-driven parking does not parse component transport a second time."""
+    """Config-driven parking consumes the resolved deployment map as-is."""
     import vrl.rewards.functions.registry as reward_registry
 
     built = _built_reward({"aesthetic": 1.0}, {"aesthetic": {}})
+    captured: dict[str, object] = {}
 
-    def unexpected_reparse(*args, **kwargs):
-        del args, kwargs
-        raise AssertionError("resolved reward inference must be consumed directly")
+    def capture(
+        names,
+        *,
+        device="cuda",
+        reward_kwargs=None,
+        inference_configs=None,
+    ):
+        del names, device, reward_kwargs
+        captured["inference_configs"] = inference_configs
 
     monkeypatch.setattr(
         reward_registry,
-        "parse_reward_inference_config",
-        unexpected_reparse,
+        "validate_reward_memory_parking_components",
+        capture,
     )
 
     validate_reward_memory_parking(
@@ -649,30 +662,37 @@ def test_shared_reward_preflight_consumes_resolved_inference(
         built=built,
     )
 
+    assert captured["inference_configs"] is built.reward.inference_configs
+
 
 def test_reward_build_consumes_resolved_inference(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The real MultiReward construction path does not parse transport twice."""
-    import vrl.rewards.functions.registry as reward_registry
+    """The MultiReward construction path consumes the resolved map as-is."""
+    from vrl.rewards.functions.registry import MultiReward
 
     built = _built_reward({"ocr": 1.0}, {})
+    captured: dict[str, object] = {}
 
-    def unexpected_reparse(*args, **kwargs):
-        del args, kwargs
-        raise AssertionError("resolved reward inference must be consumed directly")
+    def fake_from_dict(
+        cls,
+        score_dict,
+        device="cuda",
+        reward_kwargs=None,
+        memory_parking_required=None,
+        inference_configs=None,
+    ):
+        del cls, score_dict, device, reward_kwargs, memory_parking_required
+        captured["inference_configs"] = inference_configs
+        return object()
 
-    monkeypatch.setattr(
-        reward_registry,
-        "parse_reward_inference_config",
-        unexpected_reparse,
-    )
+    monkeypatch.setattr(MultiReward, "from_dict", classmethod(fake_from_dict))
 
-    reward = build_reward_function(
+    build_reward_function(
         ResolvedReward(config=built.reward, device="cpu", memory_parking_required=False),
     )
 
-    assert [name for name, _, _ in reward.rewards] == ["ocr"]
+    assert captured["inference_configs"] is built.reward.inference_configs
 
 
 def test_reward_runtime_factory_exposes_the_public_runtime_protocol() -> None:

--- a/tests/scripts/test_encode_sft_targets.py
+++ b/tests/scripts/test_encode_sft_targets.py
@@ -8,8 +8,8 @@ from omegaconf import OmegaConf
 
 from vrl.scripts.denoise import encode_targets
 from vrl.scripts.denoise.encode_targets import (
-    _resolve_target_videos,
-    _video_at_sampling_geometry,
+    _resolve_clean_targets,
+    _target_at_sampling_geometry,
 )
 from vrl.trainers.data.prompts import PromptExample
 
@@ -24,17 +24,18 @@ def test_target_preflight_uses_artifact_root_and_target_identity(tmp_path) -> No
         PromptExample(prompt="same instruction", target_video="targets/b.mp4"),
     ]
 
-    targets = _resolve_target_videos(
+    targets = _resolve_clean_targets(
         examples,
         data_root=root,
         allow_absolute=False,
     )
 
-    assert [key for key, _ in targets] == ["targets/a.mp4", "targets/b.mp4"]
-    assert [path for _, path in targets] == [
+    assert [key for key, _, _ in targets] == ["targets/a.mp4", "targets/b.mp4"]
+    assert [path for _, path, _ in targets] == [
         str(root / "targets/a.mp4"),
         str(root / "targets/b.mp4"),
     ]
+    assert [kind for _, _, kind in targets] == ["target_video", "target_video"]
 
 
 def test_target_preflight_rejects_duplicate_target_identity(tmp_path) -> None:
@@ -45,14 +46,14 @@ def test_target_preflight_rejects_duplicate_target_identity(tmp_path) -> None:
         PromptExample(prompt="second", target_video=str(target)),
     ]
 
-    with pytest.raises(ValueError, match="repeats target_video"):
-        _resolve_target_videos(examples, data_root=None, allow_absolute=True)
+    with pytest.raises(ValueError, match="repeats clean target"):
+        _resolve_clean_targets(examples, data_root=None, allow_absolute=True)
 
 
 def test_target_preflight_rejects_missing_file(tmp_path) -> None:
     example = PromptExample(prompt="missing", target_video="targets/missing.mp4")
     with pytest.raises(FileNotFoundError, match="does not exist"):
-        _resolve_target_videos([example], data_root=tmp_path, allow_absolute=False)
+        _resolve_clean_targets([example], data_root=tmp_path, allow_absolute=False)
 
 
 def test_video_geometry_rejects_short_target(monkeypatch) -> None:
@@ -62,7 +63,13 @@ def test_video_geometry_rejects_short_target(monkeypatch) -> None:
     )
 
     with pytest.raises(ValueError, match="requires 3"):
-        _video_at_sampling_geometry("short.mp4", height=4, width=4, num_frames=3)
+        _target_at_sampling_geometry(
+            "short.mp4",
+            media_type="target_video",
+            height=4,
+            width=4,
+            num_frames=3,
+        )
 
 
 def test_video_geometry_resizes_without_changing_frame_count(monkeypatch) -> None:
@@ -71,9 +78,32 @@ def test_video_geometry_resizes_without_changing_frame_count(monkeypatch) -> Non
         lambda _path, *, num_frames: torch.zeros(num_frames, 2, 3, 3),
     )
 
-    video = _video_at_sampling_geometry("target.mp4", height=4, width=6, num_frames=3)
+    video = _target_at_sampling_geometry(
+        "target.mp4",
+        media_type="target_video",
+        height=4,
+        width=6,
+        num_frames=3,
+    )
 
     assert video.shape == (1, 3, 3, 4, 6)
+
+
+def test_image_target_becomes_one_frame_video(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "vrl.utils.media.read_image_as_frames",
+        lambda _path: torch.zeros(1, 2, 3, 3),
+    )
+
+    video = _target_at_sampling_geometry(
+        "target.png",
+        media_type="target_image",
+        height=4,
+        width=6,
+        num_frames=1,
+    )
+
+    assert video.shape == (1, 3, 1, 4, 6)
 
 
 def test_entrypoint_rejects_malformed_model_before_registry_model_build(
@@ -103,5 +133,35 @@ def test_entrypoint_rejects_malformed_model_before_registry_model_build(
                 "invalid",
                 "--out",
                 str(tmp_path / "latents.pt"),
+            ],
+        )
+
+
+def test_entrypoint_forwards_composition_overrides(monkeypatch, tmp_path) -> None:
+    from vrl.config import loading as config_loading
+
+    expected_overrides = [
+        "+reward=codex_image_qa_anime_color_light",
+        "+reward=codex_image_qa_luna",
+        "+dataset=anima_color_light_ddrl",
+        "model.use_lora=false",
+        "sampling.num_steps=40",
+    ]
+
+    def capture_load_config(path, *, overrides):
+        assert path == "experiment/anima_preview3/online_grpo"
+        assert overrides == expected_overrides
+        raise RuntimeError("configuration arguments captured before model loading")
+
+    monkeypatch.setattr(config_loading, "load_config", capture_load_config)
+
+    with pytest.raises(RuntimeError, match="configuration arguments captured"):
+        encode_targets.main(
+            [
+                "--experiment",
+                "anima_preview3/online_grpo",
+                "--out",
+                str(tmp_path / "latents.pt"),
+                *expected_overrides,
             ],
         )

--- a/tests/scripts/test_online_lifecycle.py
+++ b/tests/scripts/test_online_lifecycle.py
@@ -332,6 +332,15 @@ def test_owned_ray_session_retries_shutdown_before_committing_closed() -> None:
     assert ray_api.calls == 2
 
 
+@pytest.mark.asyncio
+async def test_run_online_recipe_rejects_non_prompt_example_sequence() -> None:
+    with pytest.raises(TypeError, match="item 1 is str"):
+        await online.run_online_recipe(
+            _cfg(),
+            prompt_examples=(PromptExample(prompt="valid"), "not-an-example"),  # type: ignore[arg-type]
+        )
+
+
 def _install_common_fakes(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Any,
@@ -518,6 +527,35 @@ def _install_common_fakes(
         lambda self, path, *args, **kwargs: state["checkpoint_paths"].append(path.name),
     )
     return reward
+
+
+@pytest.mark.asyncio
+async def test_injected_prompt_examples_bypass_manifest_loader(monkeypatch, tmp_path) -> None:
+    state = _state()
+    _install_common_fakes(monkeypatch, tmp_path, state)
+    provided = PromptExample(prompt="frozen prompt", metadata={"source": "snapshot"})
+    monkeypatch.setattr(
+        online,
+        "load_prompt_examples_from_config",
+        lambda _cfg: (_ for _ in ()).throw(AssertionError("manifest path must not reopen")),
+    )
+    seen: list[PromptExample] = []
+
+    class _ReachedResolvedPrompt(RuntimeError):
+        pass
+
+    def _stop_after_selection(example: PromptExample, **_kwargs: Any) -> PromptExample:
+        seen.append(example)
+        raise _ReachedResolvedPrompt
+
+    monkeypatch.setattr(online, "resolve_prompt_example_references", _stop_after_selection)
+
+    with pytest.raises(_ReachedResolvedPrompt):
+        await online.run_online_recipe(_cfg(), prompt_examples=(provided,))
+
+    assert seen == [provided]
+    assert state["bundle_builds"] == 0
+    assert state["owner_creates"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/scripts/test_online_precision_bridge.py
+++ b/tests/scripts/test_online_precision_bridge.py
@@ -9,7 +9,10 @@ import pytest
 import torch
 from omegaconf import OmegaConf
 
-from tests.config.test_load_all_experiments import _experiment_names
+from tests.config.test_load_all_experiments import (
+    _experiment_names,
+    _load_experiment_for_static_validation,
+)
 from vrl.algorithms.logprob_mismatch import PrecisionCorrectionConfig
 from vrl.config.builders import build_configs
 from vrl.config.loading import load_config
@@ -27,7 +30,7 @@ _RECIPES = [name for name in _experiment_names() if not Path(name).name.startswi
 @pytest.mark.parametrize("experiment", _RECIPES)
 def test_bridge_uses_aligned_public_precision(experiment):
     """Checks bridge derives trainer precision from public precision."""
-    cfg = load_config(f"experiment/{experiment}")
+    cfg = _load_experiment_for_static_validation(experiment)
     trainer_config = build_configs(cfg).trainer
     policy = resolve_precision_policy(cfg)
     # The bridge contract is the role-label equality below (train/rollout labels
@@ -209,6 +212,23 @@ def test_precision_drift_guard_config_is_bridged_from_yaml():
 
     assert trainer_config.precision_drift_guard.mode == "fail"
     assert trainer_config.precision_drift_guard.max_abs_log_ratio == pytest.approx(0.02)
+
+
+def test_replay_parity_config_is_bridged_from_yaml() -> None:
+    cfg = _with_precision(
+        "sd3_5/online_grpo_ocr",
+        _plain_policy("bf16"),
+    )
+    cfg = OmegaConf.merge(
+        cfg,
+        OmegaConf.create(
+            {"trainer": {"replay_parity": {"max_abs_logprob_diff": 2.0e-4}}},
+        ),
+    )
+
+    trainer_config = build_configs(cfg).trainer
+
+    assert trainer_config.replay_parity.max_abs_logprob_diff == pytest.approx(2.0e-4)
 
 
 def test_online_metrics_csv_includes_logprob_mismatch_metrics(tmp_path):

--- a/tests/scripts/test_supervise.py
+++ b/tests/scripts/test_supervise.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import math
 import os
 import signal
 import sys
@@ -27,7 +28,7 @@ from vrl.scripts.supervise import (
 )
 from vrl.trainers.core.types import (
     ContinuousRolloutConfig,
-    DebugConfig,
+    ReplayParityConfig,
     RolloutOrchestrationConfig,
 )
 from vrl.trainers.metrics_io import (
@@ -637,21 +638,48 @@ def test_health_config_derives_strict_parity_limit_from_training_config() -> Non
     health = HealthGateConfig.from_cli(
         _health_args(),
         schedule=RolloutOrchestrationConfig(schedule_mode="strict_on_policy"),
-        debug=DebugConfig(max_abs_logprob_diff=0.004),
+        replay_parity=ReplayParityConfig(max_abs_logprob_diff=0.004),
     )
 
     assert health.continuous is None
     assert health.max_pre_update_logprob_diff == pytest.approx(0.004)
 
 
-def test_health_config_keeps_explicit_parity_override() -> None:
+def test_health_config_accepts_tighter_explicit_parity_override() -> None:
     health = HealthGateConfig.from_cli(
-        _health_args("--health-max-pre-update-logprob-diff", "0.02"),
+        _health_args("--health-max-pre-update-logprob-diff", "0.002"),
         schedule=RolloutOrchestrationConfig(schedule_mode="strict_on_policy"),
-        debug=DebugConfig(max_abs_logprob_diff=0.004),
+        replay_parity=ReplayParityConfig(max_abs_logprob_diff=0.004),
     )
 
-    assert health.max_pre_update_logprob_diff == pytest.approx(0.02)
+    assert health.max_pre_update_logprob_diff == pytest.approx(0.002)
+
+
+def test_health_config_rejects_wider_explicit_parity_override() -> None:
+    with pytest.raises(ValueError, match="cannot exceed"):
+        HealthGateConfig.from_cli(
+            _health_args("--health-max-pre-update-logprob-diff", "0.02"),
+            schedule=RolloutOrchestrationConfig(schedule_mode="strict_on_policy"),
+            replay_parity=ReplayParityConfig(max_abs_logprob_diff=0.004),
+        )
+
+
+def test_health_config_carries_the_grad_norm_spike_bound_from_cli() -> None:
+    health = HealthGateConfig.from_cli(
+        _health_args("--health-max-grad-norm", "0.8"),
+        schedule=RolloutOrchestrationConfig(schedule_mode="strict_on_policy"),
+        replay_parity=ReplayParityConfig(),
+    )
+
+    assert health.max_grad_norm == pytest.approx(0.8)
+    assert (
+        HealthGateConfig.from_cli(
+            _health_args(),
+            schedule=RolloutOrchestrationConfig(schedule_mode="strict_on_policy"),
+            replay_parity=ReplayParityConfig(),
+        ).max_grad_norm
+        == math.inf
+    )
 
 
 @pytest.mark.parametrize(
@@ -670,7 +698,7 @@ def test_health_config_derives_continuous_metrics_from_training_schedule(
             schedule_mode="continuous",
             continuous=ContinuousRolloutConfig(max_stale_policy_versions=2),
         ),
-        debug=DebugConfig(),
+        replay_parity=ReplayParityConfig(),
     )
 
     assert health.continuous is not None
@@ -688,7 +716,7 @@ def test_health_config_accepts_a_continuous_schedule_on_its_own_defaults() -> No
     health = HealthGateConfig.from_cli(
         _health_args(),
         schedule=RolloutOrchestrationConfig(schedule_mode="continuous"),
-        debug=DebugConfig(),
+        replay_parity=ReplayParityConfig(),
     )
 
     assert health.continuous is not None
@@ -705,7 +733,7 @@ def test_health_config_rejects_stale_override_wider_than_training() -> None:
                 schedule_mode="continuous",
                 continuous=ContinuousRolloutConfig(max_stale_policy_versions=1),
             ),
-            debug=DebugConfig(),
+            replay_parity=ReplayParityConfig(),
         )
 
 
@@ -714,7 +742,7 @@ def test_health_config_rejects_stale_override_for_strict_schedule() -> None:
         HealthGateConfig.from_cli(
             _health_args("--health-max-stale-policy-versions", "0"),
             schedule=RolloutOrchestrationConfig(schedule_mode="strict_on_policy"),
-            debug=DebugConfig(),
+            replay_parity=ReplayParityConfig(),
         )
 
 
@@ -771,6 +799,70 @@ def test_health_gate_reads_a_complete_online_metric_row(tmp_path) -> None:
     assert not (out / HEALTH_VERDICT_NAME).exists()
 
 
+def test_health_gate_trips_on_a_grad_norm_spike_after_the_failure_limit(tmp_path) -> None:
+    """The pre-collapse signature: a steady band, then a spike that keeps going."""
+
+    out = tmp_path / "run"
+    out.mkdir()
+    metrics = out / "metrics.csv"
+    metrics.write_text(_METRICS_HEADER + _metric_row(0, grad_norm="0.26"))
+    gate = MetricsHealthGate(HealthGateConfig(failure_limit=2, max_grad_norm=0.8), out)
+
+    assert gate.judge_new_rows() is False
+
+    metrics.write_text(metrics.read_text() + _metric_row(1, grad_norm="1.46"))
+
+    assert gate.judge_new_rows() is False
+
+    metrics.write_text(metrics.read_text() + _metric_row(2, grad_norm="2.1"))
+
+    assert gate.judge_new_rows() is True
+    verdict = json.loads((out / HEALTH_VERDICT_NAME).read_text())
+    assert verdict["epoch"] == 2
+    assert verdict["consecutive_unhealthy_rows"] == 2
+    assert any("grad_norm 2.1 is above maximum 0.8" in reason for reason in verdict["reasons"])
+    assert verdict["thresholds"]["max_grad_norm"] == 0.8
+
+
+def test_health_gate_accepts_a_grad_norm_below_the_maximum(tmp_path) -> None:
+    out = tmp_path / "run"
+    out.mkdir()
+    (out / "metrics.csv").write_text(_METRICS_HEADER + _metric_row(0, grad_norm="0.26"))
+    gate = MetricsHealthGate(HealthGateConfig(failure_limit=1, max_grad_norm=0.8), out)
+
+    assert gate.judge_new_rows() is False
+    assert not (out / HEALTH_VERDICT_NAME).exists()
+
+
+def test_health_gate_default_never_trips_on_a_large_grad_norm(tmp_path) -> None:
+    out = tmp_path / "run"
+    out.mkdir()
+    (out / "metrics.csv").write_text(_METRICS_HEADER + _metric_row(0, grad_norm="1e6"))
+    gate = MetricsHealthGate(HealthGateConfig(failure_limit=1), out)
+
+    assert gate.judge_new_rows() is False
+    assert not (out / HEALTH_VERDICT_NAME).exists()
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"max_grad_norm": 0.0}, "must be > 0"),
+        ({"max_grad_norm": -1.0}, "must be > 0"),
+        ({"max_grad_norm": float("nan")}, "must be > 0"),
+        ({"max_grad_norm": 1e-8}, "must be > min_grad_norm"),
+        ({"max_grad_norm": 0.5, "min_grad_norm": 0.5}, "must be > min_grad_norm"),
+        ({"max_grad_norm": 0.1, "min_grad_norm": 0.5}, "must be > min_grad_norm"),
+    ],
+)
+def test_health_config_rejects_a_max_grad_norm_at_or_below_the_minimum(
+    kwargs: dict[str, float],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        HealthGateConfig(**kwargs)
+
+
 def test_metrics_health_gate_cli_thresholds_are_configurable() -> None:
     args = build_parser().parse_args(
         [
@@ -791,6 +883,8 @@ def test_metrics_health_gate_cli_thresholds_are_configurable() -> None:
             "0.003",
             "--health-min-grad-norm",
             "0.0002",
+            "--health-max-grad-norm",
+            "0.8",
         ],
     )
 
@@ -802,6 +896,13 @@ def test_metrics_health_gate_cli_thresholds_are_configurable() -> None:
     assert args.health_max_stale_logprob_diff == 0.08
     assert args.health_min_reward_std == 0.003
     assert args.health_min_grad_norm == 0.0002
+    assert args.health_max_grad_norm == 0.8
+
+
+def test_metrics_health_gate_max_grad_norm_is_disabled_by_default() -> None:
+    args = build_parser().parse_args(["--config", "unit", "--health-metrics"])
+
+    assert args.health_max_grad_norm == math.inf
 
 
 @pytest.mark.parametrize(
@@ -814,6 +915,9 @@ def test_metrics_health_gate_cli_thresholds_are_configurable() -> None:
         ("--health-max-stale-logprob-diff", "nan"),
         ("--health-min-reward-std", "-1"),
         ("--health-min-grad-norm", "inf"),
+        ("--health-max-grad-norm", "0"),
+        ("--health-max-grad-norm", "-1"),
+        ("--health-max-grad-norm", "inf"),
     ],
 )
 def test_metrics_health_gate_cli_rejects_invalid_thresholds(option, value) -> None:

--- a/tests/trainers/data/test_prompts.py
+++ b/tests/trainers/data/test_prompts.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vrl.trainers.data.prompts import (
+    JsonlPromptDataset,
+    PromptExample,
+    load_prompt_examples_from_jsonl_bytes,
+)
+
+
+def test_jsonl_bytes_loader_preserves_prompt_manifest_field_behavior(tmp_path) -> None:
+    rows = [
+        {
+            "prompt": "six dancers",
+            "target_text": "six",
+            "metadata": {"split": "train"},
+            "expected_people": 6,
+        },
+        {"prompt": "eight dancers", "task_type": "text_to_image"},
+    ]
+    payload = ("\n" + "\n".join(json.dumps(row) for row in rows) + "\n").encode()
+
+    loaded = load_prompt_examples_from_jsonl_bytes(payload, source="frozen-prompts.jsonl")
+    manifest = tmp_path / "prompts.jsonl"
+    manifest.write_bytes(payload)
+
+    assert loaded == JsonlPromptDataset(manifest).examples
+    assert loaded == [
+        PromptExample(
+            prompt="six dancers",
+            target_text="six",
+            metadata={"split": "train", "expected_people": 6},
+        ),
+        PromptExample(prompt="eight dancers", task_type="text_to_image"),
+    ]
+    assert loaded[0].generation_input().task_type is None
+
+
+def test_jsonl_bytes_loader_rejects_non_utf8_payload() -> None:
+    with pytest.raises(ValueError, match=r"snapshot\.jsonl: prompt manifest must be valid UTF-8"):
+        load_prompt_examples_from_jsonl_bytes(b'\xff{"prompt":"x"}\n', source="snapshot.jsonl")
+
+
+def test_jsonl_bytes_loader_rejects_non_object_row_with_line_number() -> None:
+    payload = b'\n{"prompt":"valid"}\n["not", "an", "object"]\n'
+
+    with pytest.raises(ValueError, match=r"snapshot.jsonl:3: JSONL rows must be objects"):
+        load_prompt_examples_from_jsonl_bytes(payload, source="snapshot.jsonl")
+
+
+def test_jsonl_bytes_loader_requires_immutable_bytes() -> None:
+    with pytest.raises(TypeError, match="must be immutable bytes"):
+        load_prompt_examples_from_jsonl_bytes(bytearray(b'{"prompt":"x"}\n'))  # type: ignore[arg-type]

--- a/tests/trainers/online/_helpers.py
+++ b/tests/trainers/online/_helpers.py
@@ -139,10 +139,19 @@ def _diffusion_rollout_batch(
     )
 
 
-def _trajectory_signals(batch, log_prob, timestep_idx: int = 0):
+def _trajectory_signals(
+    batch,
+    log_prob,
+    timestep_idx: int = 0,
+    *,
+    old_log_prob=None,
+):
     from vrl.rollouts.evaluators.types import SegmentSignal, TrajectorySignalBatch
 
-    old_log_prob = torch.full_like(log_prob, float(timestep_idx))
+    if old_log_prob is None:
+        # Most trainer fakes model an unchanged-policy replay. Tests that
+        # deliberately exercise mismatch must provide the behavior value.
+        old_log_prob = log_prob.detach().clone()
     mask = torch.ones_like(log_prob)
     return TrajectorySignalBatch(
         segments={

--- a/tests/trainers/online/test_advantage_and_metrics.py
+++ b/tests/trainers/online/test_advantage_and_metrics.py
@@ -49,6 +49,7 @@ class TestAdvantageAndMetrics:
 
             def __init__(self) -> None:
                 self.loss_calls = 0
+                self.component_advantage_calls = 0
 
             def compute_advantages_from_tensors(self, rewards, group_ids):
                 advantages = torch.zeros_like(rewards)
@@ -61,6 +62,16 @@ class TestAdvantageAndMetrics:
                     std = gr.std().clamp(min=1e-8)
                     advantages[mask] = (gr - mean) / std
                 return advantages
+
+            def compute_advantages_from_components(
+                self,
+                rewards,
+                component_rewards,
+                group_ids,
+            ):
+                self.component_advantage_calls += 1
+                assert set(component_rewards) == {"observer"}
+                return self.compute_advantages_from_tensors(rewards, group_ids)
 
             def compute_loss(self, inputs):
                 signals, _advantages, old_log_probs = _algorithm_inputs(inputs)
@@ -130,7 +141,12 @@ class TestAdvantageAndMetrics:
                     device=model.weight.device,
                 )
                 log_prob = old + self.calls / 1000.0 + model.weight.view(1) * 0.0
-                return _trajectory_signals(batch, log_prob, timestep_idx)
+                return _trajectory_signals(
+                    batch,
+                    log_prob,
+                    timestep_idx,
+                    old_log_prob=old,
+                )
 
         model = nn.Linear(1, 1, bias=False)
         _stamp_model_precision(model)
@@ -175,6 +191,7 @@ class TestAdvantageAndMetrics:
         # Component metrics belong to the consumed second batch only. The first
         # step's observations must not accumulate on a shared reward object.
         assert second_step.reward_components == {"observer": pytest.approx(10.5)}
+        assert trainer.algorithm.component_advantage_calls == 2
 
     def test_cea_metrics_propagate_approx_kl(self) -> None:
         """CEA aggregation should not silently drop approx_kl."""

--- a/tests/trainers/online/test_config.py
+++ b/tests/trainers/online/test_config.py
@@ -9,7 +9,7 @@ from dataclasses import FrozenInstanceError, fields
 import pytest
 from omegaconf import OmegaConf
 
-from vrl.trainers.core.types import OptimConfig
+from vrl.trainers.core.types import DebugConfig, OptimConfig, ReplayParityConfig
 from vrl.trainers.online.config import OnlineBatchPlan, TrainerConfig
 
 
@@ -48,6 +48,20 @@ def test_trainer_config_does_not_mirror_controller_lifecycle() -> None:
     trainer_fields = {trainer_field.name for trainer_field in fields(TrainerConfig)}
 
     assert trainer_fields.isdisjoint({"total_epochs", "save_freq", "seed"})
+
+
+def test_replay_parity_is_a_correctness_config_not_a_debug_toggle() -> None:
+    trainer_fields = {trainer_field.name: trainer_field for trainer_field in fields(TrainerConfig)}
+
+    assert [debug_field.name for debug_field in fields(DebugConfig)] == ["first_step"]
+    assert trainer_fields["replay_parity"].metadata["yaml"] == "trainer.replay_parity"
+    assert ReplayParityConfig().max_abs_logprob_diff == pytest.approx(0.01)
+
+
+@pytest.mark.parametrize("limit", [-1.0, float("nan"), float("inf")])
+def test_replay_parity_rejects_invalid_limits(limit: float) -> None:
+    with pytest.raises(ValueError, match=r"trainer\.replay_parity\.max_abs_logprob_diff"):
+        ReplayParityConfig(max_abs_logprob_diff=limit)
 
 
 def test_online_batch_plan_fields_declare_public_owners() -> None:

--- a/tests/trainers/online/test_diagnostics.py
+++ b/tests/trainers/online/test_diagnostics.py
@@ -15,27 +15,80 @@ from tests.trainers.online._helpers import (
 from vrl.rollouts.evaluators.base import Evaluator
 
 
+def _make_parity_boundary_trainer(
+    tmp_path,
+    *,
+    drop_zero_advantage: bool,
+    precision_correction=None,
+):
+    import torch.nn as nn
+
+    from vrl.algorithms.logprob_mismatch import PrecisionCorrectionConfig
+    from vrl.trainers.core.types import EMAConfig, OptimConfig
+    from vrl.trainers.online import OnlineTrainer
+    from vrl.trainers.online.config import OnlineBatchPlan, TrainerConfig
+
+    class _Algorithm(_EvaluatorAlgorithmFake):
+        precision_correction = PrecisionCorrectionConfig()
+
+        class _Config:
+            kl_coef = 0.0
+
+        config = _Config()
+
+    class _Evaluator(Evaluator):
+        def evaluate(self, model, batch, timestep_idx, **kw):
+            raise AssertionError("the boundary test must not evaluate")
+
+    model = nn.Linear(1, 1, bias=False)
+    _stamp_model_precision(model)
+    return OnlineTrainer(
+        algorithm=_Algorithm(),
+        collector=CollectorControlFake(),
+        evaluator=_Evaluator(),
+        model=model,
+        config=TrainerConfig(
+            batch_plan=OnlineBatchPlan(prompts_per_batch=1, n_samples_per_prompt=2),
+            timestep_fraction=1.0,
+            drop_zero_advantage=drop_zero_advantage,
+            output_dir=str(tmp_path),
+            optim=OptimConfig(lr=0.01),
+            ema=EMAConfig(),
+            precision_correction=precision_correction or PrecisionCorrectionConfig(),
+        ),
+        device="cpu",
+    )
+
+
 class TestDiagnostics:
     """Groups tests for diagnostics."""
 
     @pytest.mark.parametrize(
-        ("model_value", "late_offset", "expected_finite", "failure_pattern"),
+        (
+            "model_value",
+            "late_offset",
+            "debug_enabled",
+            "expected_finite",
+            "failure_pattern",
+        ),
         [
-            (0.0, 0.0, True, None),
-            (0.02, 0.0, True, "first-step log-prob parity failed"),
-            (float("nan"), 0.0, False, "first-step log-prob parity failed"),
-            (0.0, 0.02, True, "full first-step log-prob parity failed"),
+            (0.0, 0.0, True, True, None),
+            (0.02, 0.0, True, True, "replay parity failed"),
+            (float("nan"), 0.0, True, False, "replay parity failed"),
+            (0.0, 0.02, True, True, "replay parity failed"),
+            (0.02, 0.0, False, True, "replay parity failed"),
         ],
     )
-    def test_first_step_debug_enforces_parity_before_optimizer(
+    def test_replay_parity_is_mandatory_while_debug_only_adds_diagnostics(
         self,
         tmp_path,
         model_value: float,
         late_offset: float,
+        debug_enabled: bool,
         expected_finite: bool,
         failure_pattern: str | None,
     ) -> None:
-        """The debug record is persisted and bad parity aborts before training."""
+        """Full replay parity aborts before training independently of debug."""
         import asyncio
         import json
 
@@ -77,7 +130,7 @@ class TestDiagnostics:
                 return list(pendings)
 
             async def collect_unscored(self, prompts, **kwargs):
-                assert kwargs["runtime_debug"] is True
+                assert kwargs["runtime_debug"] is debug_enabled
                 group_size = int(kwargs["group_size"])
                 return _diffusion_rollout_batch(
                     rewards=torch.arange(group_size, dtype=torch.float32),
@@ -111,6 +164,7 @@ class TestDiagnostics:
                     batch,
                     log_prob,
                     timestep_idx,
+                    old_log_prob=torch.full_like(log_prob, float(timestep_idx)),
                 )
 
         model = nn.Linear(1, 1, bias=False)
@@ -129,7 +183,7 @@ class TestDiagnostics:
                 drop_zero_advantage=False,
                 optim=OptimConfig(lr=0.01),
                 ema=EMAConfig(),
-                debug=DebugConfig(first_step=True),
+                debug=DebugConfig(first_step=debug_enabled),
                 train_precision="no",
                 output_dir=str(tmp_path),
             ),
@@ -146,23 +200,24 @@ class TestDiagnostics:
         debug_path = tmp_path / "training_debug.jsonl"
         records = [json.loads(line) for line in debug_path.read_text().splitlines()]
         by_event = {record["event"]: record for record in records}
-        if failure_pattern == "first-step log-prob parity failed":
-            assert list(by_event) == ["first_step_logprob_parity"]
-            assert by_event["first_step_logprob_parity"]["passed"] is False
-            assert by_event["first_step_logprob_parity"]["finite"] is expected_finite
-        elif failure_pattern == "full first-step log-prob parity failed":
-            assert list(by_event) == ["first_step_full_logprob_parity"]
-            full_record = by_event["first_step_full_logprob_parity"]
+        if failure_pattern is not None:
+            expected_events = {"replay_parity_gate"}
+            if debug_enabled and model_value != 0.0:
+                expected_events.add("first_step_logprob_parity")
+            assert set(by_event) == expected_events
+            full_record = by_event["replay_parity_gate"]
             assert full_record["passed"] is False
-            assert full_record["finite"] is True
-            assert full_record["max_abs_diff"] == pytest.approx(0.02)
+            assert full_record["finite"] is expected_finite
+            if "first_step_logprob_parity" in by_event:
+                assert by_event["first_step_logprob_parity"]["passed"] is False
+                assert by_event["first_step_logprob_parity"]["finite"] is expected_finite
         else:
             assert set(by_event) == {
-                "first_step_full_logprob_parity",
+                "replay_parity_gate",
                 "first_step_logprob_parity",
             }
             assert all(record["passed"] for record in records)
-            assert by_event["first_step_full_logprob_parity"]["max_abs_diff"] == 0.0
+            assert by_event["replay_parity_gate"]["max_abs_diff"] == 0.0
 
         if failure_pattern is not None:
             assert trainer.state.step == 0
@@ -190,7 +245,7 @@ class TestDiagnostics:
         assert grad_enabled[0] is False
         assert any(grad_enabled[1:])
 
-    def test_full_parity_gate_is_neutral_when_first_update_has_no_evaluations(
+    def test_replay_parity_stays_pending_until_first_measured_update(
         self,
         tmp_path,
     ) -> None:
@@ -201,49 +256,14 @@ class TestDiagnostics:
         zero-advantage filter; distributed all-dummy ranks hit the same shape.
         An empty snapshot must be neutral, not a parity failure.
         """
-        import torch.nn as nn
+        import json
 
-        from vrl.trainers.core.types import DebugConfig, EMAConfig, OptimConfig
-        from vrl.trainers.online import OnlineTrainer
-        from vrl.trainers.online.config import OnlineBatchPlan, TrainerConfig
+        from vrl.algorithms.types import InitialReplayStats
         from vrl.trainers.online.trainer import _ReplayMetrics
 
-        class _Algorithm(_EvaluatorAlgorithmFake):
-            required_signal_keys: tuple[str, ...] = ()
-            required_data_keys: tuple[str, ...] = ()
-
-            class _Config:
-                kl_coef = 0.0
-
-            config = _Config()
-
-            def compute_advantages_from_tensors(self, rewards, group_ids):
-                raise AssertionError("not exercised")
-
-            def compute_loss(self, inputs):
-                raise AssertionError("not exercised")
-
-        class _Evaluator(Evaluator):
-            def evaluate(self, model, batch, timestep_idx, **kw):
-                raise AssertionError("the gate must not evaluate anything")
-
-        model = nn.Linear(1, 1, bias=False)
-        _stamp_model_precision(model)
-        trainer = OnlineTrainer(
-            algorithm=_Algorithm(),
-            collector=CollectorControlFake(),
-            evaluator=_Evaluator(),
-            model=model,
-            config=TrainerConfig(
-                batch_plan=OnlineBatchPlan(prompts_per_batch=1, n_samples_per_prompt=2),
-                timestep_fraction=1.0,
-                drop_zero_advantage=True,
-                output_dir=str(tmp_path),
-                optim=OptimConfig(lr=0.01),
-                ema=EMAConfig(),
-                debug=DebugConfig(first_step=True),
-            ),
-            device="cpu",
+        trainer = _make_parity_boundary_trainer(
+            tmp_path,
+            drop_zero_advantage=True,
         )
 
         local, local_weight = _ReplayMetrics().initial_replay_snapshot()
@@ -254,7 +274,146 @@ class TestDiagnostics:
 
         assert resolved.finite is True
         assert resolved.logprob_abs_diff_max == 0.0
+        assert trainer._replay_parity_pending is True
         assert not (tmp_path / "training_debug.jsonl").exists()
+
+        at_limit = InitialReplayStats(logprob_abs_diff_max=0.01, finite=True)
+        resolved = trainer._validate_first_update_parity(at_limit, local_weight=1.0)
+
+        assert resolved.logprob_abs_diff_max == pytest.approx(0.01)
+        assert trainer._replay_parity_pending is False
+        record = json.loads((tmp_path / "training_debug.jsonl").read_text().strip())
+        assert record["event"] == "replay_parity_gate"
+        assert record["passed"] is True
+
+        # The proof belongs to this process/backend, so later updates do not
+        # repeat it until load_state_dict resets the lifecycle.
+        later_mismatch = InitialReplayStats(logprob_abs_diff_max=1.0, finite=True)
+        trainer._validate_first_update_parity(later_mismatch, local_weight=1.0)
+
+    def test_precision_drift_guard_stays_pending_until_first_trainable_update(
+        self,
+        tmp_path,
+    ) -> None:
+        """A filtered first rollout must not consume the precision guard."""
+        import asyncio
+        import json
+
+        import torch
+        import torch.nn as nn
+
+        from vrl.algorithms.types import TrainStepMetrics
+        from vrl.trainers.core.types import (
+            EMAConfig,
+            OptimConfig,
+            PrecisionDriftGuardConfig,
+        )
+        from vrl.trainers.online import OnlineTrainer
+        from vrl.trainers.online.config import OnlineBatchPlan, TrainerConfig
+
+        class _Algorithm(_EvaluatorAlgorithmFake):
+            required_signal_keys = ("log_prob",)
+            required_data_keys: tuple[str, ...] = ()
+
+            class _Config:
+                global_std = False
+                eps = 1e-8
+                adv_clip_max = 5.0
+                kl_coef = 0.0
+
+            config = _Config()
+
+            def compute_advantages_from_tensors(self, rewards, group_ids):
+                del group_ids
+                return rewards - rewards.mean()
+
+            def compute_loss(self, inputs):
+                signals, advantages, old_log_probs = _algorithm_inputs(inputs)
+                del advantages, old_log_probs
+                loss = signals.log_prob.mean()
+                return loss, TrainStepMetrics(loss=loss.item(), policy_loss=loss.item())
+
+        class _Collector(CollectorControlFake):
+            def __init__(self) -> None:
+                super().__init__()
+                self.collections = 0
+
+            async def score_rollouts(self, pendings):
+                return list(pendings)
+
+            async def collect_unscored(self, prompts, **kwargs):
+                del prompts
+                group_size = int(kwargs["group_size"])
+                self.collections += 1
+                rewards = (
+                    torch.zeros(group_size, dtype=torch.float32)
+                    if self.collections == 1
+                    else torch.arange(group_size, dtype=torch.float32)
+                )
+                return _diffusion_rollout_batch(
+                    rewards=rewards,
+                    group_ids=torch.zeros(group_size, dtype=torch.long),
+                    num_steps=2,
+                )
+
+        evaluator_calls: list[int] = []
+
+        class _Evaluator(Evaluator):
+            def evaluate(self, model, batch, timestep_idx, **kw):
+                del kw
+                evaluator_calls.append(timestep_idx)
+                return _trajectory_signals(
+                    batch,
+                    model.weight.view(1).expand(batch.rewards.shape[0]),
+                    timestep_idx,
+                )
+
+        model = nn.Linear(1, 1, bias=False)
+        _stamp_model_precision(model)
+        trainer = OnlineTrainer(
+            algorithm=_Algorithm(),
+            collector=_Collector(),
+            evaluator=_Evaluator(),
+            model=model,
+            config=TrainerConfig(
+                batch_plan=OnlineBatchPlan(prompts_per_batch=1, n_samples_per_prompt=2),
+                timestep_fraction=1.0,
+                drop_zero_advantage=True,
+                optim=OptimConfig(lr=0.01),
+                ema=EMAConfig(),
+                precision_drift_guard=PrecisionDriftGuardConfig(mode="fail"),
+                train_precision="no",
+                output_dir=str(tmp_path),
+            ),
+            device="cpu",
+        )
+        assert trainer.config.batch_plan.streaming is False
+
+        filtered_metrics = asyncio.run(trainer.step(["filtered-prompt"]))
+
+        assert filtered_metrics.adv_zero_rate == 1.0
+        assert trainer._precision_drift_guard_pending is True
+        assert trainer.state.step == 1
+        assert trainer.state.global_step == 0
+        assert evaluator_calls == []
+        assert not (tmp_path / "training_debug.jsonl").exists()
+
+        asyncio.run(trainer.step(["trainable-prompt"]))
+
+        assert trainer._precision_drift_guard_pending is False
+        assert trainer.state.step == 2
+        assert trainer.state.global_step == 1
+        records = [
+            json.loads(line)
+            for line in (tmp_path / "training_debug.jsonl").read_text().splitlines()
+        ]
+        precision_records = [
+            record for record in records if record["event"] == "precision_drift_guard"
+        ]
+        assert len(precision_records) == 1
+        assert precision_records[0]["violated"] is False
+        assert precision_records[0]["worst_stats"]["logprob_abs_diff_max"] == 0.0
+        assert all(record["event"] != "first_step_logprob_parity" for record in records)
 
     def test_fully_filtered_update_still_serializes_metrics_row(
         self,
@@ -269,45 +428,13 @@ class TestDiagnostics:
         """
         import asyncio
 
-        import torch.nn as nn
-
         from vrl.algorithms.types import InitialReplayStats
-        from vrl.trainers.core.types import DebugConfig, EMAConfig, OptimConfig
         from vrl.trainers.metrics_io import OnlineMetricRow
-        from vrl.trainers.online import OnlineTrainer
-        from vrl.trainers.online.config import OnlineBatchPlan, TrainerConfig
         from vrl.trainers.online.trainer import RolloutStats
 
-        class _Algorithm(_EvaluatorAlgorithmFake):
-            required_signal_keys: tuple[str, ...] = ()
-            required_data_keys: tuple[str, ...] = ()
-
-            class _Config:
-                kl_coef = 0.0
-
-            config = _Config()
-
-        class _Evaluator(Evaluator):
-            def evaluate(self, model, batch, timestep_idx, **kw):
-                raise AssertionError("a fully filtered update must not evaluate")
-
-        model = nn.Linear(1, 1, bias=False)
-        _stamp_model_precision(model)
-        trainer = OnlineTrainer(
-            algorithm=_Algorithm(),
-            collector=CollectorControlFake(),
-            evaluator=_Evaluator(),
-            model=model,
-            config=TrainerConfig(
-                batch_plan=OnlineBatchPlan(prompts_per_batch=1, n_samples_per_prompt=2),
-                timestep_fraction=1.0,
-                drop_zero_advantage=True,
-                output_dir=str(tmp_path),
-                optim=OptimConfig(lr=0.01),
-                ema=EMAConfig(),
-                debug=DebugConfig(),
-            ),
-            device="cpu",
+        trainer = _make_parity_boundary_trainer(
+            tmp_path,
+            drop_zero_advantage=True,
         )
 
         trainer.begin_optimizer_update()
@@ -326,6 +453,81 @@ class TestDiagnostics:
         )
 
         assert isinstance(metrics.initial_replay, InitialReplayStats)
+        assert trainer._replay_parity_pending is True
         row = OnlineMetricRow.from_step_metrics(0, metrics, ("nsfw_safety",))
         assert row.pre_update_clip_fraction == 0.0
         assert trainer.state.global_step == 0
+
+    def test_streaming_finish_enforces_parity_before_optimizer(
+        self,
+        tmp_path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import asyncio
+
+        from vrl.algorithms.logprob_mismatch import LogprobMismatchStats
+        from vrl.algorithms.types import TrainStepMetrics
+        from vrl.trainers.online.trainer import RolloutStats
+
+        trainer = _make_parity_boundary_trainer(
+            tmp_path,
+            drop_zero_advantage=False,
+        )
+        trainer.begin_optimizer_update()
+        trainer._update_had_training_work = True
+        trainer._update_agg_metrics.add(
+            TrainStepMetrics(
+                logprob_mismatch=LogprobMismatchStats(logprob_abs_diff_max=0.02),
+            ),
+            weight=1.0,
+            capture_initial_replay=True,
+        )
+        optimizer_called = False
+
+        def fail_if_called(optimizer):
+            nonlocal optimizer_called
+            del optimizer
+            optimizer_called = True
+            raise AssertionError("optimizer must remain behind the parity gate")
+
+        monkeypatch.setattr(trainer, "_clip_and_step", fail_if_called)
+
+        with pytest.raises(RuntimeError, match="replay parity failed"):
+            asyncio.run(
+                trainer.finish_optimizer_update(
+                    stats=RolloutStats(),
+                    reward_mean=0.0,
+                    reward_std=0.0,
+                    adv_mean=0.0,
+                    adv_zero_rate=0.0,
+                    adv_saturation=0.0,
+                    group_size=2.0,
+                    trained_prompt_num=1,
+                    reward_components={},
+                ),
+            )
+
+        assert optimizer_called is False
+        assert trainer._replay_parity_pending is True
+        assert trainer.state.step == 0
+        assert trainer.state.global_step == 0
+
+    def test_intentional_precision_correction_uses_its_bounded_drift_contract(
+        self,
+        tmp_path,
+    ) -> None:
+        from vrl.algorithms.logprob_mismatch import PrecisionCorrectionConfig
+        from vrl.algorithms.types import InitialReplayStats
+
+        trainer = _make_parity_boundary_trainer(
+            tmp_path,
+            drop_zero_advantage=False,
+            precision_correction=PrecisionCorrectionConfig(tis_mode="truncate"),
+        )
+
+        drift = InitialReplayStats(logprob_abs_diff_max=1.0, finite=True)
+        resolved = trainer._validate_first_update_parity(drift, local_weight=1.0)
+
+        assert resolved.logprob_abs_diff_max == pytest.approx(1.0)
+        assert trainer._replay_parity_pending is True
+        assert not (tmp_path / "training_debug.jsonl").exists()

--- a/tests/trainers/online/test_precision_drift_guard.py
+++ b/tests/trainers/online/test_precision_drift_guard.py
@@ -337,7 +337,12 @@ def test_online_trainer_precision_guard_fails_before_optimizer_when_ratio_drifts
         def evaluate(self, model, batch, timestep_idx, **kw):
             del kw
             fresh = model.weight.view(1).expand(batch.rewards.shape[0])
-            return _trajectory_signals(batch, fresh, timestep_idx)
+            return _trajectory_signals(
+                batch,
+                fresh,
+                timestep_idx,
+                old_log_prob=torch.full_like(fresh, float(timestep_idx)),
+            )
 
     algorithm = _Algorithm()
     model = torch.nn.Linear(1, 1, bias=False)

--- a/tests/trainers/online/test_sft_regularizer.py
+++ b/tests/trainers/online/test_sft_regularizer.py
@@ -23,6 +23,7 @@ from vrl.trainers.online.trainer import _ReplayMetrics
 _B, _T = 2, 4
 _LATENT = (3, 2, 2)
 _TARGET_VIDEO = "targets/training.mp4"
+_TARGET_IMAGE = "targets/training.png"
 
 
 class _Collector(CollectorControlFake):
@@ -49,7 +50,13 @@ class _Policy(nn.Module):
 
     def replay_forward_with_latents(self, batch, timestep_idx, latents):
         self.forward_calls.append((timestep_idx, latents))
-        return {"noise_pred": self.weight * latents}
+        return {
+            "noise_pred": -100.0 * self.weight * latents,
+            "noise_pred_cond": self.weight * latents,
+        }
+
+    def diffusion_pretraining_prediction(self, values):
+        return values["noise_pred_cond"]
 
 
 def _batch(scheduler) -> RolloutBatch:
@@ -123,8 +130,20 @@ def test_sft_term_flows_gradient_and_scales_with_weight(tmp_path) -> None:
 def test_sft_term_rejects_missing_target(tmp_path) -> None:
     latents = {"targets/other.mp4": torch.randn(*_LATENT)}
     trainer = _trainer(tmp_path, sft_weight=0.5, sft_latents=latents)
-    with pytest.raises(ValueError, match="no entry for target_video"):
+    with pytest.raises(ValueError, match="no entry for clean target"):
         trainer._sft_regularizer_loss(_batch(trainer.evaluator.scheduler))
+
+
+def test_sft_term_accepts_image_target_identity(tmp_path) -> None:
+    trainer = _trainer(
+        tmp_path,
+        sft_weight=0.5,
+        sft_latents={_TARGET_IMAGE: torch.randn(*_LATENT)},
+    )
+    batch = _batch(trainer.evaluator.scheduler)
+    batch.context["reward_metadata"] = {"target_image": _TARGET_IMAGE}
+
+    assert torch.isfinite(trainer._sft_regularizer_loss(batch))
 
 
 def test_sft_term_rejects_geometry_mismatch(tmp_path) -> None:

--- a/tests/trainers/online/test_state_restore.py
+++ b/tests/trainers/online/test_state_restore.py
@@ -118,10 +118,31 @@ class TestOnlineTrainerResumeState:
         """Checks load state dict resets rollout weight initialization."""
         trainer = _make_resume_trainer()
         trainer._rollout_weights_initialized = True
+        trainer._replay_parity_pending = False
 
         trainer.load_state_dict({"step": 9, "global_step": 9}, strict=True)
 
         assert trainer._rollout_weights_initialized is False
+        assert trainer._replay_parity_pending is True
+
+    @pytest.mark.parametrize("strict", [True, False])
+    def test_resume_rechecks_parity_at_nonzero_training_step(self, strict: bool) -> None:
+        from vrl.algorithms.types import InitialReplayStats
+
+        trainer = _make_resume_trainer()
+        trainer._replay_parity_pending = False
+        assert "_replay_parity_pending" not in trainer.state_dict()
+
+        trainer.load_state_dict({"step": 4, "global_step": 4}, strict=strict)
+
+        with pytest.raises(RuntimeError, match="replay parity failed"):
+            trainer._validate_first_update_parity(
+                InitialReplayStats(logprob_abs_diff_max=0.02, finite=True),
+                local_weight=1.0,
+            )
+        assert trainer.state.step == 4
+        assert trainer.state.global_step == 4
+        assert trainer._replay_parity_pending is True
 
     def test_strict_resume_requires_master_optimizer_state_after_first_step(self) -> None:
         trainer = _make_resume_trainer()

--- a/tests/trainers/online/test_step_split.py
+++ b/tests/trainers/online/test_step_split.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
 import torch
 import torch.nn as nn
 
@@ -251,6 +252,75 @@ def test_streaming_all_filtered_update_does_not_advance_policy(tmp_path) -> None
     assert sync_calls == []
     assert metrics.grad_norm == 0.0
     assert torch.equal(trainer.model.weight, initial_weight)
+    assert trainer._precision_drift_guard_pending is True
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+@pytest.mark.parametrize("drift", [0.0005, 0.1])
+def test_corrected_replay_enforces_drift_guard_on_both_update_paths(
+    tmp_path,
+    streaming: bool,
+    drift: float,
+) -> None:
+    """Correction bypasses exact parity, not the bounded first-update guard."""
+    import json
+
+    from vrl.algorithms.logprob_mismatch import PrecisionCorrectionConfig
+    from vrl.scripts.common.online import _run_streaming_optimizer_update
+    from vrl.trainers.core.types import PrecisionDriftGuardConfig
+    from vrl.trainers.online.precision_guard import PrecisionDriftError
+
+    trainer = _build_trainer(tmp_path)
+    trainer.algorithm.precision_correction = PrecisionCorrectionConfig(tis_mode="truncate")
+    trainer.config.precision_drift_guard = PrecisionDriftGuardConfig(
+        mode="fail",
+        max_abs_log_ratio=0.001,
+        max_ratio_abs_dev=0.001,
+    )
+
+    class DriftEvaluator(Evaluator):
+        def evaluate(self, model, batch, timestep_idx, **kw):
+            del kw
+            fresh = model.weight.view(1).expand(batch.rewards.shape[0]) + drift
+            return _trajectory_signals(
+                batch,
+                fresh,
+                timestep_idx,
+                old_log_prob=torch.ones_like(fresh),
+            )
+
+    trainer.evaluator = DriftEvaluator()
+    initial_weight = trainer.model.weight.detach().clone()
+
+    async def run_update():
+        if streaming:
+            return await _run_streaming_optimizer_update(
+                trainer,
+                ["p"],
+                batch_plan=OnlineBatchPlan(
+                    prompts_per_batch=1,
+                    n_samples_per_prompt=2,
+                    gradient_accumulation_steps=1,
+                ),
+            )
+        return await trainer.step(["p"])
+
+    if drift > trainer.config.precision_drift_guard.max_abs_log_ratio:
+        with pytest.raises(PrecisionDriftError, match="precision drift guard"):
+            asyncio.run(run_update())
+        assert trainer.state.global_step == 0
+        assert torch.equal(trainer.model.weight, initial_weight)
+        assert trainer._precision_drift_guard_pending is True
+    else:
+        asyncio.run(run_update())
+        assert trainer.state.global_step == 1
+        assert not torch.equal(trainer.model.weight, initial_weight)
+        assert trainer._precision_drift_guard_pending is False
+        records = [
+            json.loads(line)
+            for line in (tmp_path / "training_debug.jsonl").read_text().splitlines()
+        ]
+        assert [record["event"] for record in records] == ["precision_drift_guard"]
 
 
 def test_streaming_scaler_skipped_update_does_not_publish_weights(tmp_path) -> None:
@@ -298,3 +368,38 @@ def test_phase_events_use_the_metric_step(tmp_path) -> None:
     assert events
     assert {event["step"] for event in events} == {0}
     assert trainer.state.step == 1
+
+
+def test_streaming_profiles_training_phases(tmp_path) -> None:
+    """Streaming metrics and events cover replay, backward, and optimizer work."""
+    import json
+
+    from vrl.scripts.common.online import _run_streaming_optimizer_update
+
+    trainer = _build_trainer(tmp_path)
+    trainer.config.profile = True
+
+    metrics = asyncio.run(
+        _run_streaming_optimizer_update(
+            trainer,
+            ["p"],
+            batch_plan=OnlineBatchPlan(
+                prompts_per_batch=1,
+                n_samples_per_prompt=2,
+                gradient_accumulation_steps=1,
+            ),
+        ),
+    )
+
+    for phase in ("evaluate", "backward", "optim_step"):
+        assert metrics.phase_times[phase] > 0.0
+
+    events = [
+        json.loads(line) for line in (tmp_path / "phase_events.jsonl").read_text().splitlines()
+    ]
+    training_events = {
+        event["phase"]: event["step"]
+        for event in events
+        if event["phase"] in {"evaluate", "backward", "optim_step"}
+    }
+    assert training_events == {"evaluate": 0, "backward": 0, "optim_step": 0}

--- a/vrl/algorithms/advantages.py
+++ b/vrl/algorithms/advantages.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Mapping
+from typing import Any, ClassVar
 
 
 def all_reduce_sufficient_stats(values: Any) -> tuple[Any, Any, Any]:
@@ -58,23 +59,36 @@ def _population_std_across_ranks(rewards: Any) -> Any:
 
     import torch
 
-    g_sum, g_sumsq, g_count = all_reduce_sufficient_stats(rewards)
+    # Reward normalization epsilons such as 1e-8 underflow in fp16, so all
+    # sufficient statistics must be accumulated in at least fp32.
+    stats_rewards = (
+        rewards.float() if rewards.dtype in {torch.float16, torch.bfloat16} else rewards
+    )
+    n = rewards.numel()
+    dist = torch.distributed
+    distributed = dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1
+    if not distributed:
+        if n <= 1:
+            return stats_rewards.new_tensor(0.0)
+        variance, _mean = torch.var_mean(stats_rewards, correction=0)
+        return torch.sqrt(variance)
+
+    g_sum, g_sumsq, g_count = all_reduce_sufficient_stats(stats_rewards)
     if g_count <= 1:
-        return rewards.new_tensor(0.0)
+        return stats_rewards.new_tensor(0.0)
     g_mean = g_sum / g_count
     g_var = (g_sumsq / g_count) - g_mean * g_mean
     return torch.sqrt(torch.clamp(g_var, min=0.0)).to(rewards.device)
 
 
-def group_relative_advantages(
+def _standardize_group_rewards(
     rewards: Any,
     group_ids: Any,
     *,
     eps: float,
-    adv_clip_max: float,
     global_std: bool,
 ) -> Any:
-    """Normalize rewards within each group using the GRPO advantage contract.
+    """Standardize rewards within each group without applying a final clamp.
 
     ``global_std`` shares one denominator across all groups; under DDP it is the
     true cross-rank std (see ``_population_std_across_ranks``). ``global_std=False``
@@ -94,12 +108,155 @@ def group_relative_advantages(
             advantages[mask] = 0.0
             continue
 
-        mean = group_rewards.mean()
-        std = global_std_value if global_std else group_rewards.std(unbiased=False)
+        # Separate mean/std reductions can round a constant decimal group to a
+        # non-zero std and create an O(1) fake advantage. One var_mean reduction
+        # keeps centering and variance consistent; fp32 also keeps eps representable.
+        stats_rewards = (
+            group_rewards.float()
+            if group_rewards.dtype in {torch.float16, torch.bfloat16}
+            else group_rewards
+        )
+        variance, mean = torch.var_mean(stats_rewards, correction=0)
+        std = global_std_value if global_std else torch.sqrt(variance)
         denom = torch.clamp(std, min=eps)
-        group_adv = (group_rewards - mean) / denom
-        advantages[mask] = torch.clamp(group_adv, -adv_clip_max, adv_clip_max)
+        advantages[mask] = ((stats_rewards - mean) / denom).to(rewards.dtype)
     return advantages
 
 
-__all__ = ["group_relative_advantages"]
+def group_relative_advantages(
+    rewards: Any,
+    group_ids: Any,
+    *,
+    eps: float,
+    adv_clip_max: float,
+    global_std: bool,
+) -> Any:
+    """Normalize and clamp rewards within each GRPO prompt group."""
+
+    import torch
+
+    advantages = _standardize_group_rewards(
+        rewards,
+        group_ids,
+        eps=eps,
+        global_std=global_std,
+    )
+    return torch.clamp(advantages, -adv_clip_max, adv_clip_max)
+
+
+class GroupAdvantageEstimator:
+    """Compute scalar or multi-objective group-relative advantages.
+
+    The estimator binds the resolved reward weights to one algorithm instance.
+    This keeps reward configuration out of the public algorithm dataclass and
+    provides a lifecycle owner for strategies that may gain runtime state.
+    """
+
+    __slots__ = (
+        "adv_clip_max",
+        "component_weights",
+        "eps",
+        "global_std",
+        "strategy",
+    )
+
+    DEFAULT_STRATEGY = "weighted_sum_raw"
+
+    def __init__(
+        self,
+        *,
+        eps: float,
+        adv_clip_max: float,
+        global_std: bool,
+        strategy: str = DEFAULT_STRATEGY,
+        component_weights: Mapping[str, float] | None = None,
+    ) -> None:
+        self.validate_strategy(strategy)
+        self.eps = float(eps)
+        self.adv_clip_max = float(adv_clip_max)
+        self.global_std = bool(global_std)
+        self.strategy = strategy
+        self.component_weights = {
+            name: float(weight) for name, weight in (component_weights or {}).items()
+        }
+
+    @classmethod
+    def validate_strategy(cls, strategy: str) -> None:
+        """Reject an unknown public strategy name at configuration time."""
+
+        if strategy not in cls._STRATEGIES:
+            raise ValueError(
+                f"unknown advantage_combine strategy {strategy!r}; "
+                f"available: {sorted(cls._STRATEGIES)}",
+            )
+
+    def compute(
+        self,
+        rewards: Any,
+        group_ids: Any,
+        *,
+        component_rewards: Mapping[str, Any] | None = None,
+    ) -> Any:
+        """Compute advantages using the configured aggregation strategy."""
+
+        compute_strategy = self._STRATEGIES[self.strategy]
+        return compute_strategy(self, rewards, component_rewards, group_ids)
+
+    def _normalize_weighted_rewards(
+        self,
+        rewards: Any,
+        _component_rewards: Mapping[str, Any] | None,
+        group_ids: Any,
+    ) -> Any:
+        """Normalize the weighted total already produced by the reward runtime."""
+
+        return group_relative_advantages(
+            rewards,
+            group_ids,
+            eps=self.eps,
+            adv_clip_max=self.adv_clip_max,
+            global_std=self.global_std,
+        )
+
+    def _normalize_components_then_sum(
+        self,
+        _rewards: Any,
+        component_rewards: Mapping[str, Any] | None,
+        group_ids: Any,
+    ) -> Any:
+        """Normalize each objective, weighted-sum it, then clamp once."""
+
+        import torch
+
+        if not component_rewards:
+            raise ValueError("normalized_sum requires per-component rewards")
+        component_names = set(component_rewards)
+        weight_names = set(self.component_weights)
+        if component_names != weight_names:
+            raise ValueError(
+                "reward component keys must match configured weights; "
+                f"missing={sorted(weight_names - component_names)}, "
+                f"unknown={sorted(component_names - weight_names)}",
+            )
+
+        total = None
+        # Stable ordering keeps global-std collectives aligned across DDP ranks.
+        for name in sorted(component_rewards):
+            advantage = _standardize_group_rewards(
+                component_rewards[name],
+                group_ids,
+                eps=self.eps,
+                global_std=self.global_std,
+            )
+            weighted = self.component_weights[name] * advantage
+            total = weighted if total is None else total + weighted
+        return torch.clamp(total, -self.adv_clip_max, self.adv_clip_max)
+
+    # This table is both dispatch and the source of truth for public validation.
+    _STRATEGIES: ClassVar = {
+        DEFAULT_STRATEGY: _normalize_weighted_rewards,
+        "normalized_sum": _normalize_components_then_sum,
+    }
+
+
+__all__ = ["GroupAdvantageEstimator", "group_relative_advantages"]

--- a/vrl/algorithms/base.py
+++ b/vrl/algorithms/base.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from vrl.algorithms.types import TrainStepMetrics
 
@@ -65,4 +65,19 @@ class Algorithm(Protocol):
         inputs: AlgorithmInput,
     ) -> tuple[Any, TrainStepMetrics]:
         """Compute loss from strict trajectory-native algorithm inputs."""
+        ...
+
+
+@runtime_checkable
+class ComponentAdvantageAlgorithm(Protocol):
+    """Optional algorithm capability for raw reward-component observations."""
+
+    def compute_advantages_from_components(
+        self,
+        rewards: Any,
+        component_rewards: dict[str, Any],
+        group_ids: Any,
+    ) -> Any:
+        """Compute advantages from weighted totals and their raw components."""
+
         ...

--- a/vrl/algorithms/grpo/continuous.py
+++ b/vrl/algorithms/grpo/continuous.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
-from vrl.algorithms.advantages import group_relative_advantages
+from vrl.algorithms.advantages import GroupAdvantageEstimator
 from vrl.algorithms.logprob_mismatch import (
     PrecisionCorrectionConfig,
     apply_rejection_sample_mask,
@@ -23,6 +24,31 @@ class GroupAdvantageConfig:
     eps: float = 1e-4
     adv_clip_max: float = 5.0
     global_std: bool = False
+    # How multiple reward components are combined into one advantage.
+    # "weighted_sum_raw" (default, legacy): sum weighted raw rewards then
+    # normalize once — a high-variance component dominates. "normalized_sum"
+    # (DanceGRPO-style): normalize each component to a per-group advantage first,
+    # then weighted-sum, so no reward dominates by scale/variance. New
+    # multi-objective strategies plug into vrl.algorithms.advantages.
+    advantage_combine: str = GroupAdvantageEstimator.DEFAULT_STRATEGY
+
+    def __post_init__(self) -> None:
+        GroupAdvantageEstimator.validate_strategy(self.advantage_combine)
+
+    def build_estimator(
+        self,
+        *,
+        component_weights: Mapping[str, float] | None = None,
+    ) -> GroupAdvantageEstimator:
+        """Build the runtime estimator from this algorithm configuration."""
+
+        return GroupAdvantageEstimator(
+            eps=self.eps,
+            adv_clip_max=self.adv_clip_max,
+            global_std=self.global_std,
+            strategy=self.advantage_combine,
+            component_weights=component_weights,
+        )
 
 
 @dataclass(slots=True)
@@ -78,9 +104,15 @@ class GRPO:
     # this True so the trainer rejects the strict + ppo_epochs=1 no-op config.
     requires_active_trust_region = False
 
-    def __init__(self, config: GRPOConfig | None = None) -> None:
+    def __init__(
+        self,
+        config: GRPOConfig | None = None,
+        *,
+        advantage_estimator: GroupAdvantageEstimator | None = None,
+    ) -> None:
         self.config = config or GRPOConfig()
         self._initialize_precision_correction()
+        self._initialize_advantage_estimator(advantage_estimator)
 
     def _initialize_precision_correction(self) -> None:
         """Install the trainer-injected rollout/replay correction capability."""
@@ -89,6 +121,16 @@ class GRPO:
         # injects trainer.precision_correction here at construction so the knobs
         # live at the trainer level, not in the algorithm's hyperparameters.
         self.precision_correction = PrecisionCorrectionConfig()
+
+    def _initialize_advantage_estimator(
+        self,
+        advantage_estimator: GroupAdvantageEstimator | None,
+    ) -> None:
+        """Bind one resolved advantage strategy to this algorithm instance."""
+
+        if advantage_estimator is None:
+            advantage_estimator = self.config.build_estimator()
+        self.advantage_estimator = advantage_estimator
 
     def compute_advantages_from_tensors(
         self,
@@ -100,13 +142,27 @@ class GRPO:
         Groups are identified by ``group_ids``: samples sharing the same
         group_id are normalized together (GRPO per-prompt normalization).
         """
-        cfg = self.config
-        return group_relative_advantages(
+        return self.advantage_estimator.compute(
             rewards,
             group_ids,
-            eps=cfg.eps,
-            adv_clip_max=cfg.adv_clip_max,
-            global_std=cfg.global_std,
+        )
+
+    def compute_advantages_from_components(
+        self,
+        rewards: Any,
+        component_rewards: dict[str, Any],
+        group_ids: Any,
+    ) -> Any:
+        """Compute advantages with optional raw reward-component observations.
+
+        The default strategy consumes ``rewards``, the authoritative weighted
+        total from the reward runtime. Component-aware strategies consume the
+        raw observations using the weights bound to ``advantage_estimator``.
+        """
+        return self.advantage_estimator.compute(
+            rewards,
+            group_ids,
+            component_rewards=component_rewards,
         )
 
     def compute_loss(
@@ -418,10 +474,16 @@ class FlowDPPO(GRPO):
     # collapses to -advantages * 1 (plain REINFORCE). Require a moving policy.
     requires_active_trust_region = True
 
-    def __init__(self, config: FlowDPPOConfig | None = None) -> None:
+    def __init__(
+        self,
+        config: FlowDPPOConfig | None = None,
+        *,
+        advantage_estimator: GroupAdvantageEstimator | None = None,
+    ) -> None:
         cfg = config or FlowDPPOConfig()
         self.config: FlowDPPOConfig = cfg
         self._initialize_precision_correction()
+        self._initialize_advantage_estimator(advantage_estimator)
 
     def compute_loss(self, inputs: AlgorithmInput) -> tuple[Any, TrainStepMetrics]:
         import torch
@@ -539,10 +601,16 @@ class GRPOGuard(GRPO):
     # vanishes, and the loss collapses to plain GRPO. Require a moving policy.
     requires_active_trust_region = True
 
-    def __init__(self, config: GRPOGuardConfig | None = None) -> None:
+    def __init__(
+        self,
+        config: GRPOGuardConfig | None = None,
+        *,
+        advantage_estimator: GroupAdvantageEstimator | None = None,
+    ) -> None:
         cfg = config or GRPOGuardConfig()
         self.config: GRPOGuardConfig = cfg
         self._initialize_precision_correction()
+        self._initialize_advantage_estimator(advantage_estimator)
 
     def compute_loss(self, inputs: AlgorithmInput) -> tuple[Any, TrainStepMetrics]:
         import torch

--- a/vrl/algorithms/grpo/multisegment.py
+++ b/vrl/algorithms/grpo/multisegment.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     import torch
 
+from vrl.algorithms.advantages import GroupAdvantageEstimator
 from vrl.algorithms.grpo.token import TokenGRPO, TokenGRPOConfig
 from vrl.algorithms.trajectory import AlgorithmInput
 from vrl.algorithms.types import PolicyUpdateStats, TrainStepMetrics
@@ -39,9 +40,14 @@ class MultiSegmentTokenGRPOConfig(TokenGRPOConfig):
 class MultiSegmentTokenGRPO(TokenGRPO):
     """Apply TokenGRPO independently per segment, then average by weight."""
 
-    def __init__(self, config: MultiSegmentTokenGRPOConfig | None = None) -> None:
+    def __init__(
+        self,
+        config: MultiSegmentTokenGRPOConfig | None = None,
+        *,
+        advantage_estimator: GroupAdvantageEstimator | None = None,
+    ) -> None:
         cfg = config or MultiSegmentTokenGRPOConfig()
-        super().__init__(cfg)
+        super().__init__(cfg, advantage_estimator=advantage_estimator)
         self.config: MultiSegmentTokenGRPOConfig = cfg
 
     def compute_loss(

--- a/vrl/algorithms/grpo/token.py
+++ b/vrl/algorithms/grpo/token.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     import torch
 
+from vrl.algorithms.advantages import GroupAdvantageEstimator
 from vrl.algorithms.grpo.continuous import GRPO, ClippedPolicyConfig
 from vrl.algorithms.logprob_mismatch import (
     apply_rejection_sample_mask,
@@ -31,10 +32,16 @@ class TokenGRPOConfig(ClippedPolicyConfig):
 class TokenGRPO(GRPO):
     """GRPO with per-token PPO loss for autoregressive policies."""
 
-    def __init__(self, config: TokenGRPOConfig | None = None) -> None:
+    def __init__(
+        self,
+        config: TokenGRPOConfig | None = None,
+        *,
+        advantage_estimator: GroupAdvantageEstimator | None = None,
+    ) -> None:
         cfg = config or TokenGRPOConfig()
         self.config: TokenGRPOConfig = cfg
         self._initialize_precision_correction()
+        self._initialize_advantage_estimator(advantage_estimator)
 
     def compute_loss(
         self,

--- a/vrl/config/builders.py
+++ b/vrl/config/builders.py
@@ -12,10 +12,7 @@ from vrl.config.algorithm import algorithm_config_class
 from vrl.config.precision import (
     PrecisionPolicy,
 )
-from vrl.config.reward_inference import (
-    RewardInferenceConfig,
-    parse_reward_inference_config,
-)
+from vrl.config.reward_inference import RewardInferenceConfig
 from vrl.config.schema import RewardConfig, RootConfig
 from vrl.config.validation import (
     dataclass_field_names,
@@ -83,12 +80,10 @@ class RewardRuntimeConfig:
             keys = ", ".join(f"reward.kwargs.{name}" for name in unknown_kwargs)
             raise ValueError(f"reward kwargs configured for unknown component(s): {keys}")
         kwargs = {name: dict(reward.kwargs.get(name) or {}) for name in weights}
+        # RewardConfig already parsed the typed inference section; absent
+        # entries execute in-process.
         inference_configs = {
-            name: parse_reward_inference_config(
-                (kwargs.get(name) or {}).get("inference"),
-                context=f"reward.kwargs.{name}.inference",
-            )
-            for name in weights
+            name: reward.inference.get(name, RewardInferenceConfig()) for name in weights
         }
         return cls(
             weights=weights,

--- a/vrl/config/lint.py
+++ b/vrl/config/lint.py
@@ -79,13 +79,16 @@ def unregistered_code_paths() -> list[str]:
 def unknown_yaml_keys() -> dict[str, list[str]]:
     """Config sweep: unknown keys per experiment, for every shipped experiment."""
 
-    from vrl.config.loading import list_bundled_configs, load_config
+    from vrl.config.loading import compose_config, list_bundled_configs
     from vrl.config.unknown_keys import find_unknown_keys
 
     offenders: dict[str, list[str]] = {}
     for logical_name in list_bundled_configs("experiment"):
         name = logical_name.removeprefix("experiment/").removesuffix(".yaml")
-        unknown = find_unknown_keys(load_config(f"experiment/{name}"))
+        # Unknown-key lint only needs the composed mapping. Keeping mandatory
+        # deployment values unresolved lets it inspect fail-closed templates
+        # without inventing a bundle identity or weakening runtime loading.
+        unknown = find_unknown_keys(compose_config(f"experiment/{name}"))
         if unknown:
             offenders[name] = unknown
     return offenders

--- a/vrl/config/loading.py
+++ b/vrl/config/loading.py
@@ -145,12 +145,23 @@ def _load_one(
     return merged
 
 
-def load_config(
+def compose_config(
     path: str | Path,
     overrides: list[str] | None = None,
     root: Path | None = None,
 ) -> DictConfig:
-    """Load a YAML config with defaults overlay and dotlist overrides."""
+    """Compose defaults and overrides without resolving mandatory values.
+
+    This inspection boundary exists for structural tooling such as unknown-key
+    linting. Runtime entrypoints must use :func:`load_config`, which resolves
+    interpolations and rejects every mandatory ``???`` value.
+
+    ``+group=option`` appends an independent preset after the base config, in
+    command-line order (for example, ``+reward=ocr +dataset=drawbench_train_192``).
+    These layers merge, rather than replace, existing sections; start with a
+    reward/data-neutral recipe when selecting those roles at launch. All scalar
+    dotlist overrides apply last, regardless of their command-line position.
+    """
 
     config_root: ConfigSource = root.resolve() if root is not None else _BUNDLED_CONFIGS
 
@@ -161,12 +172,26 @@ def load_config(
     else:
         source = _join_config(config_root, _normalize_config_name(path))
 
-    # ``/group=option`` overrides swap a defaults entry; everything else is a
-    # dotlist value override merged after composition.
+    # ``/group=option`` swaps defaults; ``+group=option`` appends presets.
+    # Dotlist values merge after both kinds of composition.
     default_overrides: dict[str, str] = {}
+    preset_overlays: list[str] = []
     value_overrides: list[str] = []
     for override in overrides or []:
-        if isinstance(override, str) and override.startswith("/") and "=" in override:
+        if isinstance(override, str) and override.startswith("+"):
+            if "=" not in override:
+                raise ValueError(f"invalid additive preset override: {override!r}")
+            group, option = (part.strip() for part in override[1:].split("=", 1))
+            name = f"{group}/{option}"
+            if (
+                not group
+                or not option
+                or group.startswith("+")
+                or any(part in ("", ".", "..") for part in name.replace("\\", "/").split("/"))
+            ):
+                raise ValueError(f"invalid additive preset override: {override!r}")
+            preset_overlays.append(_normalize_config_name(name))
+        elif isinstance(override, str) and override.startswith("/") and "=" in override:
             key, value = override.split("=", 1)
             group = key.strip().lstrip("/")
             if not group:
@@ -177,9 +202,28 @@ def load_config(
 
     cfg = _load_one(source, config_root, default_overrides=default_overrides)
 
+    for name in preset_overlays:
+        # A selected policy may itself inherit another preset in the same group.
+        # Resolve it independently so base-default replacements cannot rewrite
+        # that inheritance into a cycle or change the explicitly selected layer.
+        overlay = _load_one(_join_config(config_root, name), config_root)
+        cfg = OmegaConf.merge(cfg, overlay)
+
     if value_overrides:
         cfg = OmegaConf.merge(cfg, OmegaConf.from_dotlist(value_overrides))
         assert isinstance(cfg, DictConfig)
+
+    return cfg
+
+
+def load_config(
+    path: str | Path,
+    overrides: list[str] | None = None,
+    root: Path | None = None,
+) -> DictConfig:
+    """Load a YAML config with defaults overlay and required-value checks."""
+
+    cfg = compose_config(path, overrides=overrides, root=root)
 
     OmegaConf.resolve(cfg)
 
@@ -197,4 +241,9 @@ def load_config(
     return cfg
 
 
-__all__ = ["bundled_config_resource", "list_bundled_configs", "load_config"]
+__all__ = [
+    "bundled_config_resource",
+    "compose_config",
+    "list_bundled_configs",
+    "load_config",
+]

--- a/vrl/config/presets/experiment/sana/online_grpo_aesthetic_fullparam.yaml
+++ b/vrl/config/presets/experiment/sana/online_grpo_aesthetic_fullparam.yaml
@@ -55,7 +55,8 @@ trainer:
   output_dir: outputs/sana_aesthetic_fullparam
   debug:
     first_step: true
-    # The corrected rollout/replay path is bit-exact. Keep a tiny diagnostic
+  replay_parity:
+    # The corrected rollout/replay path is bit-exact. Keep a tiny parity
     # allowance for future kernel revisions, still two orders tighter than the
     # algorithm's 1e-4 importance-ratio clip boundary.
     max_abs_logprob_diff: 1.0e-6

--- a/vrl/config/presets/experiment/wan_2_1/online_grpo_droid_fullparam_fsdp_3x_l4.yaml
+++ b/vrl/config/presets/experiment/wan_2_1/online_grpo_droid_fullparam_fsdp_3x_l4.yaml
@@ -94,9 +94,10 @@ reward:
       score_key: robotics_blend
       artifact_dir: ${trainer.output_dir}/reward_artifacts
       debug_dir: ${trainer.output_dir}/reward_debug
-      inference:
-        endpoint: http://127.0.0.1:8301
-        expected_model: robotics-video-reward-v1
+  inference:
+    robotics_video_reward:
+      endpoint: http://127.0.0.1:8301
+      expected_model: robotics-video-reward-v1
 
 trainer:
   output_dir: outputs/wan_robotics_physics_4x_l4/droid_fullparam_fsdp_3x_l4

--- a/vrl/config/presets/experiment/wan_2_1/online_grpo_hpsv3_fsdp_4x_l40s.yaml
+++ b/vrl/config/presets/experiment/wan_2_1/online_grpo_hpsv3_fsdp_4x_l40s.yaml
@@ -33,7 +33,7 @@ defaults:
 
 actor:
   optim:
-    lr: 1.0e-5
+    lr: 1.0e-4            # reference: train.learning_rate = 1e-4
   # All six prompt groups per streaming microbatch (GAS=1): per-sample replay
   # keeps GPU activations bounded regardless, and collecting the whole update
   # before one backward pass cuts phase park/wake transitions from 18 to 3 per
@@ -43,16 +43,34 @@ actor:
   # 8 of this smoke).
   microbatch_size: 6
   ppo_epochs: 1
-  # Paper parity (Flash-GRPO trains 51% of the 20 denoise steps) and half the
-  # replay compute vs the repo-wide 0.99 default.
-  timestep_fraction: 0.51
+  # Mechanism 1: train EXACTLY the rollout's stochastic step. The trained
+  # subset is the recorded window, not a trainer-side draw, so
+  # timestep_fraction must be 1.0 (the sde_window validation refuses any other
+  # value). The earlier strided/0.51 pairing trained a FIXED even-indexed
+  # subset every update, including the near-terminal step where cps collapses
+  # std_dev_t — see the rollout block.
+  timestep_selection: sde_window
+  timestep_fraction: 1.0
   # Mandatory at this geometry: the 32,760-token replay backward OOM'd a
-  # 44.4GiB L40S under compile-alone (measured 2026-08-16); checkpointing
-  # excludes compile, so the run is eager end to end.
+  # 44.4GiB L40S under compile-alone (measured 2026-08-16). Compile is scoped
+  # to the rollout instead (see model.torch_compile).
   gradient_checkpointing: full
+  ema:
+    enable: true          # reference: EMAModuleWrapper(trainable_parameters,
+    decay: 0.9            #   decay=0.9,
+    update_interval: 8    #   update_step_interval=8)
 
 algorithm:
-  kl_coef: 0.004
+  kind: flash_grpo        # rectified loss; the three mechanisms of arXiv:2605.15980
+  # The paper's 1e-3. FlashGRPOConfig already defaults to it, but
+  # recipe/online/denoise_grpo.yaml sets 1e-4 and a YAML value shadows a
+  # dataclass default, so the paper value only takes effect when written here.
+  # 1e-4 sits BELOW this recipe's rollout-vs-replay numeric drift: run50
+  # measured pre_update_clip_fraction=0.78 before a single weight update, i.e.
+  # the clip was gating on noise and randomly zeroing ~40% of the gradient.
+  # Watch that metric on update 1 — it must start near zero.
+  clip_ratio: 1.0e-3
+  kl_coef: 0.0            # reference: no KL term; clip_ratio is the rail
   # Flash-GRPO normalizes with the std of the whole 96-sample update; under
   # FSDP this is the true cross-rank std (advantages.py all-reduces it).
   global_std: true
@@ -60,7 +78,11 @@ algorithm:
 model:
   local_files_only: true
   torch_compile:
-    enable: false
+    enable: true
+    # Rollout only: the FSDP2 trainer runs eager + gradient checkpointing,
+    # both of which inductor refuses. Measured 446s -> 324s per 4-video group.
+    scope: rollout
+    mode: default
 
 distributed:
   training:
@@ -88,9 +110,27 @@ rollout:
   prompts_per_batch: 6
   n_samples_per_prompt: 4
   samples_per_generation_batch: 1
-  noise_level: 0.7
+  # The window machinery lives on the SDE branch of the denoise loop; wan's
+  # family default is 'native', which bypasses it. 'native' is not merely a
+  # different sampler here: it stores the scheduler's DETERMINISTIC step as the
+  # action and then scores it under the SDE proposal, so the "log-prob" is a
+  # fixed quadratic in the model output rather than the density of a draw.
+  # E[grad log pi] != 0 under it, and the negative-advantage branch has no
+  # equilibrium. That is why run50 descended on its own objective.
+  denoise_mode: sde
+  # flow_grpo SDE at noise_level 1.0 is the reference parameterization
+  # (std_dev_t = sigmas[1] * sigma) and its log-prob carries the 1/(2*sigma^2)
+  # normalizer. cps omits that normalizer while compute_kl_divergence keeps it,
+  # and cps derives std_dev_t from sigma_prev, which collapses to 2.7e-3 at the
+  # near-terminal step — inflating the effective KL weight there by ~7e4.
+  noise_level: 1.0
   sde:
-    type: cps
+    type: flow_grpo
+    # Mechanisms 1+2: ONE stochastic step per trajectory, drawn once per
+    # generation request so every sample of a prompt group shares it
+    # (iso-temporal grouping). Reference: index ~ U{0..9}.
+    window_size: 1
+    window_range: [0, 10]
   # 24 trajectories x 81 frames per rank per update: bf16 host-side leaves or
   # host RAM becomes the wall before GPU memory does.
   trajectory_storage:

--- a/vrl/config/presets/experiment/wan_2_1/online_grpo_robotics_physics_4x_l4.yaml
+++ b/vrl/config/presets/experiment/wan_2_1/online_grpo_robotics_physics_4x_l4.yaml
@@ -91,11 +91,11 @@ reward:
       media_type: video
       artifact_format: mp4
       artifact_dir: ${trainer.output_dir}/reward_artifacts
-      inference:
-        kind: http
-        endpoint: http://127.0.0.1:8300
-        timeout_s: 1800
-        expected_model: unified-reward-robotics
+  inference:
+    unified_reward_video:
+      kind: http
+      endpoint: http://127.0.0.1:8300
+      expected_model: unified-reward-robotics
 
 trainer:
   rollout_orchestration:

--- a/vrl/config/presets/experiment/wan_2_1/online_grpo_unified_reward_overlap_gate.yaml
+++ b/vrl/config/presets/experiment/wan_2_1/online_grpo_unified_reward_overlap_gate.yaml
@@ -105,12 +105,12 @@ reward:
       # Resolves under the service's configured artifact_roots.
       # HTTP carries the control protocol; the mp4 moves as a filesystem path.
       artifact_dir: ${trainer.output_dir}/reward_artifacts
-      # Transport only. Physical isolation is the service's own attestation.
-      inference:
-        kind: http
-        endpoint: http://127.0.0.1:8300
-        timeout_s: 1800
-        expected_model: unified-reward-overlap-gate
+  # Transport only. Physical isolation is the service's own attestation.
+  inference:
+    unified_reward_video:
+      kind: http
+      endpoint: http://127.0.0.1:8300
+      expected_model: unified-reward-overlap-gate
 
 trainer:
   output_dir: outputs/wan_videoscore2_overlap_gate

--- a/vrl/config/presets/reward/animereward_quality_http.yaml
+++ b/vrl/config/presets/reward/animereward_quality_http.yaml
@@ -15,8 +15,8 @@ reward:
       artifact_format: tensor
       artifact_dir: ${trainer.output_dir}/reward_artifacts
       debug_dir: ${trainer.output_dir}/reward_debug
-      inference:
-        kind: http
-        endpoint: http://127.0.0.1:8310
-        timeout_s: 1800
-        expected_model: animereward-quality
+  inference:
+    animereward_quality:
+      kind: http
+      endpoint: http://127.0.0.1:8310
+      expected_model: animereward-quality

--- a/vrl/config/presets/reward/robotics_video_reward_http.yaml
+++ b/vrl/config/presets/reward/robotics_video_reward_http.yaml
@@ -12,8 +12,8 @@ reward:
       artifact_format: mp4
       artifact_dir: ${trainer.output_dir}/reward_artifacts
       debug_dir: ${trainer.output_dir}/reward_debug
-      inference:
-        kind: http
-        endpoint: http://127.0.0.1:8301
-        timeout_s: 1800
-        expected_model: robotics-video-reward
+  inference:
+    robotics_video_reward:
+      kind: http
+      endpoint: http://127.0.0.1:8301
+      expected_model: robotics-video-reward

--- a/vrl/config/presets/reward/unified_reward_video_http.yaml
+++ b/vrl/config/presets/reward/unified_reward_video_http.yaml
@@ -31,8 +31,8 @@ reward:
       # Persist raw axes for reward-hacking audits; the selected scalar alone
       # cannot reveal alignment, physics, and style moving in opposite directions.
       debug_dir: ${trainer.output_dir}/reward_debug
-      inference:
-        kind: http
-        endpoint: http://127.0.0.1:8300
-        timeout_s: 1800
-        expected_model: unified-reward-video
+  inference:
+    unified_reward_video:
+      kind: http
+      endpoint: http://127.0.0.1:8300
+      expected_model: unified-reward-video

--- a/vrl/config/reward_inference.py
+++ b/vrl/config/reward_inference.py
@@ -48,6 +48,7 @@ class RewardInferenceConfig:
     endpoint: str = ""
     timeout_s: float = 1800.0
     expected_model: str = ""
+    expected_model_version: str = ""
 
     def __post_init__(self) -> None:
         if self.kind not in {"in_process", "http"}:
@@ -59,12 +60,15 @@ class RewardInferenceConfig:
             raise ValueError("reward inference.timeout_s must be a finite number > 0")
         endpoint = self.endpoint.strip()
         expected_model = self.expected_model.strip()
+        expected_model_version = self.expected_model_version.strip()
         object.__setattr__(self, "timeout_s", timeout_s)
         object.__setattr__(self, "expected_model", expected_model)
+        object.__setattr__(self, "expected_model_version", expected_model_version)
         if self.kind == "in_process":
-            if endpoint or expected_model:
+            if endpoint or expected_model or expected_model_version:
                 raise ValueError(
-                    "reward inference.kind=in_process cannot set endpoint or expected_model",
+                    "reward inference.kind=in_process cannot set endpoint, expected_model, "
+                    "or expected_model_version",
                 )
             object.__setattr__(self, "endpoint", endpoint)
             return
@@ -104,18 +108,16 @@ def reward_inference_configs_from_cfg(cfg: Any) -> dict[str, RewardInferenceConf
 
     reward = cfg_get(cfg, "reward", None)
     components = cfg_get(reward, "components", {}) if reward is not None else {}
-    kwargs = cfg_get(reward, "kwargs", {}) if reward is not None else {}
+    inference = cfg_get(reward, "inference", {}) if reward is not None else {}
     if not isinstance(components, Mapping):
         return {}
-    kwargs = kwargs if isinstance(kwargs, Mapping) else {}
+    inference = inference if isinstance(inference, Mapping) else {}
     resolved: dict[str, RewardInferenceConfig] = {}
     for raw_name in components:
         name = str(raw_name)
-        component_kwargs = cfg_get(kwargs, name, {}) or {}
-        inference = cfg_get(component_kwargs, "inference", None)
         resolved[name] = parse_reward_inference_config(
-            inference,
-            context=f"reward.kwargs.{name}.inference",
+            cfg_get(inference, name, None),
+            context=f"reward.inference.{name}",
         )
     return resolved
 

--- a/vrl/config/schema.py
+++ b/vrl/config/schema.py
@@ -32,7 +32,10 @@ from vrl.config.base import ConfigBase
 from vrl.config.data import DataLoaderName, manifest_sources, resolve_data_loader
 from vrl.config.model_schema import ModelSection
 from vrl.config.precision import PrecisionConfig
-from vrl.config.reward_inference import parse_reward_inference_config
+from vrl.config.reward_inference import (
+    RewardInferenceConfig,
+    parse_reward_inference_config,
+)
 from vrl.config.sampling_schema import SamplingSection
 from vrl.config.unknown_keys import OPEN, ConfigBlock
 from vrl.generation.execution.types import BatchPlacementStrategy
@@ -51,12 +54,34 @@ from vrl.utils.profiling import TorchProfilerConfig
 
 
 class RewardConfig(ConfigBase):
+    model_config = ConfigDict(extra="ignore", arbitrary_types_allowed=True)
+
     # reward names are user-chosen — open by design
     components: Annotated[dict[str, Any], OPEN]
     # each reward's kwargs contract is owned and validated by the reward class
     # itself at construction (vrl/rewards/), same as model families — the
     # config layer does not duplicate per-reward knowledge
     kwargs: Annotated[dict[str, Any], OPEN] = Field(default_factory=dict)
+    # Per-component transport/deployment, keyed by the same user-chosen names.
+    # A component without an entry executes in-process.
+    inference: Annotated[dict[str, RewardInferenceConfig], OPEN] = Field(
+        default_factory=dict,
+    )
+
+    @field_validator("inference", mode="before")
+    @classmethod
+    def _parse_inference(cls, value: object) -> object:
+        # RewardInferenceConfig is a frozen dataclass, not a pydantic model;
+        # parse entries here so errors name the reward.inference.<name> path.
+        if not isinstance(value, Mapping):
+            return value
+        return {
+            str(name): parse_reward_inference_config(
+                entry,
+                context=f"reward.inference.{name}",
+            )
+            for name, entry in value.items()
+        }
 
     @model_validator(mode="after")
     def _validate_reward(self) -> RewardConfig:
@@ -66,11 +91,12 @@ class RewardConfig(ConfigBase):
                 raise ValueError(
                     f"reward.kwargs.{name} must be a mapping, got {type(sub).__name__}",
                 )
-            if isinstance(sub, dict):
-                parse_reward_inference_config(
-                    sub.get("inference"),
-                    context=f"reward.kwargs.{name}.inference",
-                )
+
+        unknown_inference = sorted(set(self.inference) - set(self.components))
+        if unknown_inference:
+            raise ValueError(
+                f"reward.inference configured for unknown component(s): {unknown_inference}",
+            )
 
         # Zero keeps a scorer observation-only: it is still computed and logged
         # but contributes nothing to the optimization reward.
@@ -183,7 +209,7 @@ class DataConfig(ConfigBase):
     split: str | None = None
     cache_dir: str | None = None
     # Precomputed clean-latents shard for the GRPO diffusion-loss regularizer
-    # (algorithm.sft_weight > 0): {target_video -> VAE latents} written by
+    # (algorithm.sft_weight > 0): {target image/video -> VAE latents} written by
     # vrl/scripts/denoise/encode_targets.py. reader: run_online_recipe.
     sft_latents: str | None = None
     max_train_samples: Any = None

--- a/vrl/config/unknown_keys.py
+++ b/vrl/config/unknown_keys.py
@@ -148,6 +148,8 @@ def _as_mapping(value: Any) -> Mapping[str, Any] | None:
 
 
 def _collect_unknown(value: Any, block: Any, path: str, out: list[str]) -> None:
+    from omegaconf import DictConfig, OmegaConf
+
     if block is OPEN:
         return
     mapping = _as_mapping(value)
@@ -168,6 +170,10 @@ def _collect_unknown(value: Any, block: Any, path: str, out: list[str]) -> None:
             continue
         child_block = block.children.get(key)
         if child_block is not None:
+            # Structural lint checks names before runtime composition supplies
+            # mandatory blocks. Reading their values here would resolve ???.
+            if isinstance(mapping, DictConfig) and OmegaConf.is_missing(mapping, key):
+                continue
             _collect_unknown(mapping[key], child_block, child_path, out)
 
 

--- a/vrl/models/families/cosmos/anima/model.py
+++ b/vrl/models/families/cosmos/anima/model.py
@@ -347,6 +347,16 @@ class AnimaModel(CosmosReplayForward, LoraModelMixin, DiffusionModelBase):
             "noise_pred_uncond": noise_pred_uncond,
         }
 
+    def diffusion_pretraining_prediction(self, values: dict[str, Any]) -> Any:
+        """Use Anima's raw conditional flow velocity for clean-data training.
+
+        Anima applies classifier-free guidance directly to raw flow velocities.
+        The guided value is an inference extrapolation, while the checkpoint's
+        diffusion objective was learned on the conditional branch itself.
+        """
+
+        return values["noise_pred_cond"]
+
     def export_batch_context(self, state: AnimaSamplingState) -> dict[str, Any]:
         return {
             "guidance_scale": state.guidance_scale,
@@ -381,6 +391,33 @@ class AnimaModel(CosmosReplayForward, LoraModelMixin, DiffusionModelBase):
             do_cfg=batch_context["cfg"] and batch_context["guidance_scale"] > 1.0,
             padding_mask=shared_replay_tensor(replay_tensors, batch_context, "padding_mask"),
         )
+
+    def encode_video_to_latents(self, video: torch.Tensor) -> torch.Tensor:
+        """Encode clean images into Anima's scheduler-domain latents.
+
+        The offline clean-target encoder represents an image as a one-frame
+        ``[B, C, T, H, W]`` video. Using the deterministic posterior mode makes
+        a generated anchor shard reproducible, while this normalization is the
+        exact inverse of ``decode_latents`` below.
+        """
+
+        x = (video.to(self.vae.dtype) * 2.0 - 1.0).to(self.device)
+        with torch.no_grad():
+            encoded = torch.cat(
+                [self.vae.encode(sample.unsqueeze(0)).latent_dist.mode() for sample in x],
+                dim=0,
+            )
+        latents_mean = (
+            torch.tensor(self.vae.config.latents_mean)
+            .view(1, self.vae.config.z_dim, 1, 1, 1)
+            .to(encoded.device, encoded.dtype)
+        )
+        latents_std = (
+            torch.tensor(self.vae.config.latents_std)
+            .view(1, self.vae.config.z_dim, 1, 1, 1)
+            .to(encoded.device, encoded.dtype)
+        )
+        return (encoded - latents_mean) / latents_std
 
     def decode_latents(self, latents: torch.Tensor) -> torch.Tensor:
         def _transform(batch: torch.Tensor) -> torch.Tensor:

--- a/vrl/models/steps/denoise/base.py
+++ b/vrl/models/steps/denoise/base.py
@@ -126,6 +126,17 @@ class DiffusionModelBase(ReplayRequestContract, nn.Module, ABC):
 
         return self.forward_step(state, step_idx)
 
+    def diffusion_pretraining_prediction(self, values: dict[str, Any]) -> Any:
+        """Return the model output expressed in its pretraining target domain.
+
+        Most families expose that value as the finalized ``noise_pred`` used by
+        their scheduler. Families whose CFG branch values have different
+        semantics override this seam instead of making the trainer infer model
+        math from generic dictionary keys.
+        """
+
+        return values["noise_pred"]
+
     def _reject_unsupported_negative_prompt(
         self,
         negative_prompt: str | list[str] | None,

--- a/vrl/rewards/artifacts.py
+++ b/vrl/rewards/artifacts.py
@@ -72,6 +72,7 @@ class InMemoryRewardArtifactStore:
             artifacts.append(
                 RewardInferenceArtifact(
                     artifact_id=f"{sample.sample_id}:in-memory",
+                    sample_id=sample.sample_id,
                     path="",
                     media=sample.output,
                     prompt=str(sample.prompt),
@@ -182,6 +183,7 @@ class DiskRewardArtifactStore:
             # InferenceRewardFunction._write_debug; the store writes media only.
             artifact = RewardInferenceArtifact(
                 artifact_id=artifact_id,
+                sample_id=sample.sample_id,
                 path=str(path),
                 prompt=str(sample.prompt),
                 size_bytes=size_bytes,

--- a/vrl/rewards/functions/registry.py
+++ b/vrl/rewards/functions/registry.py
@@ -17,10 +17,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-from vrl.config.reward_inference import (
-    RewardInferenceConfig,
-    parse_reward_inference_config,
-)
+from vrl.config.reward_inference import RewardInferenceConfig
 from vrl.rewards.base import (
     DiskArtifactRewardFunction,
     RewardCleanupError,
@@ -171,8 +168,7 @@ class MultiReward(RewardFunction):
         e.g. ``{"ocr": {"debug_dir": "out/ocr_debug"}}``.
 
         Config-driven callers pass their already-resolved ``inference_configs``.
-        Direct callers may omit it and use raw component kwargs as this public
-        construction boundary's source.
+        Direct callers may omit it; every component then executes in-process.
         """
         _register_builtins()
         reward_kwargs = reward_kwargs or {}
@@ -180,11 +176,7 @@ class MultiReward(RewardFunction):
         reward_classes = {name: get_reward(name) for name in configured_weights}
         if inference_configs is None:
             resolved_inference_configs: Mapping[str, RewardInferenceConfig] = {
-                name: parse_reward_inference_config(
-                    dict(reward_kwargs.get(name) or {}).get("inference"),
-                    context=f"reward.kwargs.{name}.inference",
-                )
-                for name in configured_weights
+                name: RewardInferenceConfig() for name in configured_weights
             }
         else:
             component_names = set(configured_weights)
@@ -210,13 +202,12 @@ class MultiReward(RewardFunction):
             reward_cls = reward_classes[name]
             # `or {}`: a bare YAML key (kwargs: <name>:) parses as None.
             extra = dict(reward_kwargs.get(name) or {})
-            extra.pop("inference", None)
             reserved_runtime_keys = sorted(set(extra) & {"scorer", "runtime"})
             if reserved_runtime_keys:
                 raise ValueError(
                     f"reward.kwargs.{name} cannot set runtime injection keys "
                     f"{reserved_runtime_keys}; configure reward inference through "
-                    "reward.kwargs.<name>.inference",
+                    "reward.inference.<name>",
                 )
             inference = resolved_inference_configs[name]
             if "execution" in extra:
@@ -335,19 +326,13 @@ def validate_reward_memory_parking_components(
 
     Config-driven callers pass ``inference_configs`` from ``RewardRuntimeConfig``.
     The fallback preserves this validator as a boundary for direct ``MultiReward``
-    construction, where raw component kwargs are the only available source.
+    construction, where every component executes in-process.
     """
 
     _register_builtins()
     kwargs_by_name = reward_kwargs or {}
     if inference_configs is None:
-        inference_configs = {
-            name: parse_reward_inference_config(
-                dict(kwargs_by_name.get(name) or {}).get("inference"),
-                context=f"reward.kwargs.{name}.inference",
-            )
-            for name in names
-        }
+        inference_configs = {name: RewardInferenceConfig() for name in names}
     component_names = set(names)
     inference_names = set(inference_configs)
     if inference_names != component_names:

--- a/vrl/rewards/inference.py
+++ b/vrl/rewards/inference.py
@@ -21,6 +21,9 @@ class RewardInferenceArtifact:
     """Stable artifact consumed by reward inference workers."""
 
     artifact_id: str
+    # Display/audit provenance: preserves the rollout identity across artifact
+    # materialization and the remote reward-service boundary.
+    sample_id: str
     path: str
     prompt: str = ""
     size_bytes: int | None = None
@@ -33,6 +36,10 @@ class RewardInferenceArtifact:
     def __post_init__(self) -> None:
         if not self.artifact_id:
             raise ValueError("RewardInferenceArtifact.artifact_id is required")
+        if not isinstance(self.sample_id, str):
+            raise TypeError("RewardInferenceArtifact.sample_id must be a str")
+        if not self.sample_id:
+            raise ValueError("RewardInferenceArtifact.sample_id must be non-empty")
         if not self.path and self.media is None:
             raise ValueError(
                 "RewardInferenceArtifact requires a materialized path or in-memory media",

--- a/vrl/rewards/runtime.py
+++ b/vrl/rewards/runtime.py
@@ -499,7 +499,7 @@ def build_reward_scorer(
     if "service_url" in cfg:
         raise ValueError(
             "worker_config.service_url was removed; configure "
-            "reward.kwargs.<component>.inference.kind=http and inference.endpoint",
+            "reward.inference.<component>.kind=http and its endpoint",
         )
     deployment = parse_reward_inference_config(
         inference,

--- a/vrl/rewards/service/client.py
+++ b/vrl/rewards/service/client.py
@@ -58,6 +58,7 @@ class HttpRewardScorer:
         *,
         timeout_s: float | None = None,
         expected_model: str | None = None,
+        expected_model_version: str | None = None,
     ) -> None:
         from vrl.config.reward_inference import (
             RewardInferenceConfig,
@@ -69,15 +70,20 @@ class HttpRewardScorer:
                 raise ValueError(
                     "HttpRewardScorer requires inference.kind=http",
                 )
-            if timeout_s is not None or expected_model is not None:
+            if (
+                timeout_s is not None
+                or expected_model is not None
+                or expected_model_version is not None
+            ):
                 raise ValueError(
-                    "timeout_s/expected_model are owned by the RewardInferenceConfig; "
-                    "do not also pass them as keyword arguments",
+                    "timeout_s/expected_model/expected_model_version are owned by the "
+                    "RewardInferenceConfig; do not also pass them as keyword arguments",
                 )
             # Validated and normalized by the config's own __post_init__.
             service_url = service.endpoint
             timeout_s = service.timeout_s
             expected_model = service.expected_model
+            expected_model_version = service.expected_model_version
         else:
             service_url = validate_http_origin(
                 str(service),
@@ -85,12 +91,16 @@ class HttpRewardScorer:
             )
             timeout_s = 1800.0 if timeout_s is None else timeout_s
             expected_model = "" if expected_model is None else expected_model
+            expected_model_version = (
+                "" if expected_model_version is None else expected_model_version
+            )
         if timeout_s <= 0:
             raise ValueError("reward service timeout_s must be > 0")
 
         self._base_url = service_url
         self._timeout = aiohttp.ClientTimeout(total=float(timeout_s))
         self._expected_model = str(expected_model).strip()
+        self._expected_model_version = str(expected_model_version).strip()
         self._session: aiohttp.ClientSession | None = None
         self._session_loop: asyncio.AbstractEventLoop | None = None
         self._session_lock = asyncio.Lock()
@@ -248,6 +258,20 @@ class HttpRewardScorer:
                     details={
                         "expected_model": self._expected_model,
                         "actual_model": info.model_name,
+                        "actual_version": info.model_version,
+                    },
+                )
+            if self._expected_model_version and info.model_version != self._expected_model_version:
+                raise RemoteRewardServiceError(
+                    RewardServiceErrorCode.BAD_REQUEST.value,
+                    "reward service model version mismatch: "
+                    f"expected={self._expected_model_version!r}, "
+                    f"actual={info.model_version!r}",
+                    retryable=False,
+                    details={
+                        "expected_model": self._expected_model,
+                        "actual_model": info.model_name,
+                        "expected_version": self._expected_model_version,
                         "actual_version": info.model_version,
                     },
                 )

--- a/vrl/rewards/service/protocol.py
+++ b/vrl/rewards/service/protocol.py
@@ -14,9 +14,10 @@ from typing import Any
 # The one protocol identifier: trainer client and standalone service can be
 # deployed at different versions, so a mismatched peer must fail loudly (426)
 # instead of silently misreading fields. v3 dropped the protocol string, the
-# capability array, and the artifact-transport field — fixed facts of the
-# service are guaranteed by this version, not advertised per request.
-WIRE_VERSION = 3
+# capability array, and the artifact-transport field; v4 adds the original
+# sample identity to artifact provenance. Fixed facts of the service are
+# guaranteed by this version, not advertised per request.
+WIRE_VERSION = 4
 
 
 # Keep the exported enum's historical ``str(member)`` representation; the wire
@@ -46,8 +47,6 @@ class RewardServiceInfo:
     """Discoverable service identity and scheduling facts."""
 
     model_name: str
-    # Display/provenance-only until the typed client config gains a separate
-    # expected_model_version field; expected_model currently gates model_name.
     model_version: str
     # The one genuinely deployment-dependent fact: whether the operator proved
     # this service's accelerators are isolated from the training topology, so

--- a/vrl/rewards/types.py
+++ b/vrl/rewards/types.py
@@ -14,6 +14,11 @@ import math
 from dataclasses import dataclass, field
 from typing import Any
 
+# Internal schema key joining rollout prompt groups across the reward boundary.
+# The collector is the only writer; batch-capable rewards consume the opaque
+# value by equality and must never reconstruct it from sample ids or prompt text.
+REWARD_GROUP_ID_METADATA_KEY = "reward_group_id"
+
 
 @dataclass(slots=True)
 class RewardSample:
@@ -68,4 +73,8 @@ class RewardOutput:
         object.__setattr__(self, "timing_ms", timing_ms)
 
 
-__all__ = ["RewardOutput", "RewardSample"]
+__all__ = [
+    "REWARD_GROUP_ID_METADATA_KEY",
+    "RewardOutput",
+    "RewardSample",
+]

--- a/vrl/rollouts/collector/batch_builder.py
+++ b/vrl/rollouts/collector/batch_builder.py
@@ -18,6 +18,7 @@ import torch
 
 from vrl.generation import GenerationOutput
 from vrl.rewards import RewardSample
+from vrl.rewards.types import REWARD_GROUP_ID_METADATA_KEY
 from vrl.rollouts.batch import RolloutBatch
 from vrl.trajectory import (
     RewardView,
@@ -72,13 +73,21 @@ class TrajectoryRolloutBatchBuilder:
                 f"sample_rows={len(self.output.sample_rows)}, outputs={batch_size}",
             )
         samples: list[RewardSample] = []
+        if REWARD_GROUP_ID_METADATA_KEY in self.context.metadata:
+            raise ValueError(
+                f"reward metadata key {REWARD_GROUP_ID_METADATA_KEY!r} is collector-owned",
+            )
         for index, row in enumerate(self.output.sample_rows):
+            metadata = dict(self.context.metadata)
+            metadata[REWARD_GROUP_ID_METADATA_KEY] = (
+                f"{self.output.request_id}:prompt:{row.prompt_index}"
+            )
             samples.append(
                 RewardSample(
                     prompt=row.prompt,
                     output=reward_outputs[index],
                     sample_id=row.sample_id,
-                    metadata=dict(self.context.metadata),
+                    metadata=metadata,
                 ),
             )
         return tuple(samples)

--- a/vrl/rollouts/collector/core.py
+++ b/vrl/rollouts/collector/core.py
@@ -226,8 +226,15 @@ class RolloutCollector:
         trajectory_storage_policy = self.config.trajectory_storage
         builders = []
         for rollout in unscored:
+            reward_metadata = dict(rollout.collector_request.metadata)
+            policy_version = rollout.collector_request.request.policy_version
+            if policy_version is not None:
+                # The scorer owns rollout audit artifacts before the trainer has
+                # an epoch number. Policy version is the stable update identity
+                # across supervisor resume; keep it beside the scored media.
+                reward_metadata["rollout_policy_version"] = int(policy_version)
             context = RolloutBatchBuildContext(
-                metadata=dict(rollout.collector_request.metadata),
+                metadata=reward_metadata,
                 # Collector/continuous-owner output is host-owned. The trainer
                 # moves the completed batch to its device later; creating reward
                 # tensors here on the trainer GPU would race backward.

--- a/vrl/scripts/common/factory.py
+++ b/vrl/scripts/common/factory.py
@@ -120,6 +120,13 @@ def build_algorithm_and_evaluator(
     if algorithm_section is None:
         raise ValueError("online recipe requires an algorithm section")
     kind = algorithm_section.kind
+    if kind == "diffusion_dpo":
+        raise ValueError(
+            "diffusion_dpo is an offline recipe and is not supported by common online recipe",
+        )
+    reward = built.reward
+    if reward is None:
+        raise ValueError("online recipe requires reward configuration")
     diffusion_logprob_kinds = {"grpo", "dance_grpo", "flash_grpo", "flow_dppo", "grpo_guard"}
     precision = built.precision
     if precision.diffusion_math != "fp32" and kind not in diffusion_logprob_kinds:
@@ -167,14 +174,29 @@ def build_algorithm_and_evaluator(
                 "implement the full-sequence scheduler target required by "
                 "algorithm.sft_weight; set sft_weight=0",
             )
+        advantage_estimator = algorithm_config.build_estimator(
+            component_weights=reward.weights,
+        )
         if kind == "flow_dppo":
-            algorithm: object = FlowDPPO(algorithm_config)
+            algorithm: object = FlowDPPO(
+                algorithm_config,
+                advantage_estimator=advantage_estimator,
+            )
         elif kind == "grpo_guard":
-            algorithm = GRPOGuard(algorithm_config)
+            algorithm = GRPOGuard(
+                algorithm_config,
+                advantage_estimator=advantage_estimator,
+            )
         elif kind == "flash_grpo":
-            algorithm = FlashGRPO(algorithm_config)
+            algorithm = FlashGRPO(
+                algorithm_config,
+                advantage_estimator=advantage_estimator,
+            )
         else:
-            algorithm = GRPO(algorithm_config)
+            algorithm = GRPO(
+                algorithm_config,
+                advantage_estimator=advantage_estimator,
+            )
         if is_chunk_autoregressive:
             if precision.diffusion_math != "fp32":
                 raise ValueError(
@@ -238,7 +260,15 @@ def build_algorithm_and_evaluator(
             from vrl.rollouts.evaluators.token import TokenLogProbEvaluator
 
             evaluator = TokenLogProbEvaluator()
-        return AlgorithmEvaluatorPair(algorithm=TokenGRPO(algorithm_config), evaluator=evaluator)
+        return AlgorithmEvaluatorPair(
+            algorithm=TokenGRPO(
+                algorithm_config,
+                advantage_estimator=algorithm_config.build_estimator(
+                    component_weights=reward.weights,
+                ),
+            ),
+            evaluator=evaluator,
+        )
 
     if kind == "token_grpo_multisegment":
         from vrl.algorithms.grpo.multisegment import (
@@ -259,7 +289,12 @@ def build_algorithm_and_evaluator(
         segment_flags = dict(algorithm_config.train_segments or {})
         enabled_segments = tuple(name for name, enabled in segment_flags.items() if bool(enabled))
         return AlgorithmEvaluatorPair(
-            algorithm=MultiSegmentTokenGRPO(algorithm_config),
+            algorithm=MultiSegmentTokenGRPO(
+                algorithm_config,
+                advantage_estimator=algorithm_config.build_estimator(
+                    component_weights=reward.weights,
+                ),
+            ),
             evaluator=MultiSegmentTokenLogProbEvaluator(enabled_segments=enabled_segments),
         )
 
@@ -278,11 +313,6 @@ def build_algorithm_and_evaluator(
         return AlgorithmEvaluatorPair(
             algorithm=DiffusionNFT(algorithm_config),
             evaluator=None,
-        )
-
-    if kind == "diffusion_dpo":
-        raise ValueError(
-            "diffusion_dpo is an offline recipe and is not supported by common online recipe",
         )
 
     raise ValueError(f"unsupported online algorithm.kind: {kind!r}")

--- a/vrl/scripts/common/online.py
+++ b/vrl/scripts/common/online.py
@@ -6,7 +6,7 @@ import gc
 import inspect
 import logging
 import os
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -56,6 +56,7 @@ from vrl.trainers.checkpointing import (
 )
 from vrl.trainers.data import (
     PromptBatchSampler,
+    PromptExample,
     load_prompt_examples_from_config,
     resolve_prompt_example_references,
 )
@@ -740,8 +741,25 @@ class OnlineRecipeRun:
 
 async def run_online_recipe(
     cfg: DictConfig,
+    *,
+    prompt_examples: Sequence[PromptExample] | None = None,
 ) -> None:
     """Run a family online training job through shared recipe glue."""
+
+    provided_examples: list[PromptExample] | None = None
+    if prompt_examples is not None:
+        if isinstance(prompt_examples, str | bytes) or not isinstance(
+            prompt_examples,
+            Sequence,
+        ):
+            raise TypeError("prompt_examples must be a sequence of PromptExample objects")
+        provided_examples = list(prompt_examples)
+        for index, example in enumerate(provided_examples):
+            if not isinstance(example, PromptExample):
+                raise TypeError(
+                    "prompt_examples must contain only PromptExample objects; "
+                    f"item {index} is {type(example).__name__}",
+                )
 
     _preflight_production_video_reward(cfg)
     resolved = resolve_online_run(cfg)
@@ -833,7 +851,11 @@ async def run_online_recipe(
         strict=resume_config.strict,
     )
 
-    examples = load_prompt_examples_from_config(cfg.data)
+    examples = (
+        load_prompt_examples_from_config(cfg.data)
+        if provided_examples is None
+        else provided_examples
+    )
     data_config = built.root.data
     artifact_data_root = data_config.artifact_data_root if data_config is not None else None
     examples = [

--- a/vrl/scripts/denoise/encode_targets.py
+++ b/vrl/scripts/denoise/encode_targets.py
@@ -1,4 +1,4 @@
-"""Encode a manifest's target videos into the ``data.sft_latents`` shard.
+"""Encode a manifest's clean target images or videos into ``data.sft_latents``.
 
 The GRPO diffusion-loss regularizer (``algorithm.sft_weight``, the
 Cosmos-Predict2.5 paper's anti-reward-hacking term) trains against CLEAN
@@ -14,9 +14,9 @@ experiment config rather than free-form arguments:
         --preview-out outputs/cosmos_predict25_sft_target_roundtrip.mp4
 
 Requires the family model to expose ``encode_video_to_latents`` and every
-manifest row to carry a ``target_video`` artifact. The shard is keyed by that
-stable artifact identity, not prompt text: real fine-tuning manifests may use
-the same instruction for several distinct target videos.
+manifest row to carry exactly one ``target_image`` or ``target_video`` artifact.
+The shard is keyed by that stable artifact identity, not prompt text: a
+fine-tuning manifest may use the same instruction for several clean targets.
 """
 
 from __future__ import annotations
@@ -51,7 +51,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--preview-out",
         default=None,
-        help="decode the first encoded target and write an mp4 round-trip preview",
+        help="decode the first target and write a PNG (image) or MP4 (video) preview",
     )
     parser.add_argument(
         "--storage-dtype",
@@ -59,26 +59,45 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         default="preserve",
         help="On-disk latent dtype; bf16 reduces replicated trainer host memory.",
     )
+    parser.add_argument(
+        "overrides",
+        nargs="*",
+        help=(
+            "Ordered preset overlays (+reward=ocr +dataset=...) and OmegaConf "
+            "dotlist overrides (model.use_lora=false sampling.num_steps=40)."
+        ),
+    )
     return parser
 
 
-def _video_at_sampling_geometry(
+def _target_at_sampling_geometry(
     path: str,
     *,
+    media_type: str,
     height: int,
     width: int,
     num_frames: int,
 ) -> Any:
-    """Read a target video as ``[1, C, T, H, W]`` in [0,1] at the train shape."""
+    """Read a clean target as ``[1, C, T, H, W]`` at the training shape."""
 
     import torch.nn.functional as F
 
-    from vrl.utils.media import read_video_frames
+    from vrl.utils.media import read_image_as_frames, read_video_frames
 
-    frames = read_video_frames(path, num_frames=num_frames)  # [T,H,W,3] in [0,1]
+    if media_type == "target_image":
+        if num_frames != 1:
+            raise ValueError(
+                f"target image {path} cannot supervise a {num_frames}-frame run; "
+                "provide target_video instead of silently repeating one frame",
+            )
+        frames = read_image_as_frames(path)
+    elif media_type == "target_video":
+        frames = read_video_frames(path, num_frames=num_frames)
+    else:  # pragma: no cover - resolve_clean_target owns this closed set
+        raise ValueError(f"unsupported clean target field: {media_type}")
     if int(frames.shape[0]) != num_frames:
         raise ValueError(
-            f"target video {path} yielded {int(frames.shape[0])} frames, but the "
+            f"clean target {path} yielded {int(frames.shape[0])} frames, but the "
             f"training sampling geometry requires {num_frames}; rebuild the target "
             "clip at the training frame count instead of silently padding or "
             "interpolating supervision",
@@ -94,42 +113,41 @@ def _video_at_sampling_geometry(
     return video.permute(1, 0, 2, 3).unsqueeze(0)  # [1,3,T,H,W]
 
 
-def _resolve_target_videos(
+def _resolve_clean_targets(
     examples: list[Any],
     *,
     data_root: str | Path | None,
     allow_absolute: bool,
-) -> list[tuple[str, str]]:
+) -> list[tuple[str, str, str]]:
     """Resolve and validate stable target identities before loading a model."""
 
     from vrl.trainers.data.artifacts import resolve_prompt_example_artifacts
+    from vrl.trainers.data.sft_latents import resolve_clean_target
 
-    targets: list[tuple[str, str]] = []
+    targets: list[tuple[str, str, str]] = []
     seen_target_keys: set[str] = set()
     for index, example in enumerate(examples):
-        target_key = str(getattr(example, "target_video", "") or "").strip()
-        if not target_key:
+        try:
+            target = resolve_clean_target(example)
+        except ValueError as exc:
+            raise ValueError(f"manifest row {index} ({example.prompt!r}): {exc}") from exc
+        if target.key in seen_target_keys:
             raise ValueError(
-                f"manifest row {index} ({example.prompt!r}) has no target_video; "
-                "the sft shard needs one clean video per training example",
+                f"manifest row {index} repeats clean target {target.key!r}; "
+                "the target artifact is the sft shard identity and must be unique",
             )
-        if target_key in seen_target_keys:
-            raise ValueError(
-                f"manifest row {index} repeats target_video {target_key!r}; "
-                "target_video is the sft shard identity and must be unique",
-            )
-        seen_target_keys.add(target_key)
+        seen_target_keys.add(target.key)
         resolved = resolve_prompt_example_artifacts(
             example,
             data_root=data_root,
             allow_absolute=allow_absolute,
         )
-        resolved_target = Path(resolved.target_video)
+        resolved_target = Path(str(getattr(resolved, target.field)))
         if not resolved_target.is_file():
             raise FileNotFoundError(
-                f"manifest row {index} target_video does not exist: {resolved_target}",
+                f"manifest row {index} {target.field} does not exist: {resolved_target}",
             )
-        targets.append((target_key, str(resolved_target)))
+        targets.append((target.key, str(resolved_target), target.field))
     return targets
 
 
@@ -149,7 +167,7 @@ def main(argv: list[str] | None = None) -> None:
     from vrl.trainers.data import load_prompt_examples_from_config
     from vrl.trainers.data.sft_latents import save_sft_latents
 
-    cfg = load_config(f"experiment/{args.experiment}")
+    cfg = load_config(f"experiment/{args.experiment}", overrides=args.overrides)
     root = parse_config(cfg)
     precision = resolve_precision_policy(root)
     if root.model is None:
@@ -177,7 +195,7 @@ def main(argv: list[str] | None = None) -> None:
     allow_absolute = bool(
         OmegaConf.select(cfg, "data.allow_absolute_artifact_paths", default=False),
     )
-    targets = _resolve_target_videos(
+    targets = _resolve_clean_targets(
         examples,
         data_root=data_root,
         allow_absolute=allow_absolute,
@@ -212,9 +230,10 @@ def main(argv: list[str] | None = None) -> None:
         "fp16": torch.float16,
         "fp32": torch.float32,
     }[args.storage_dtype]
-    for index, (target_key, target) in enumerate(targets):
-        video = _video_at_sampling_geometry(
+    for index, (target_key, target, media_type) in enumerate(targets):
+        video = _target_at_sampling_geometry(
             str(target),
+            media_type=media_type,
             height=height,
             width=width,
             num_frames=num_frames,
@@ -225,10 +244,18 @@ def main(argv: list[str] | None = None) -> None:
             stored = stored.to(dtype=storage_dtype)
         latents_by_target[target_key] = stored.cpu()
         if args.preview_out and index == 0:
-            from vrl.utils.media import write_mp4
+            from vrl.utils.media import write_mp4, write_png
 
             decoded = model.decode_latents(latents)
-            write_mp4(decoded, args.preview_out, fps=fps)
+            preview_path = Path(args.preview_out)
+            if media_type == "target_image":
+                if preview_path.suffix.lower() != ".png":
+                    raise ValueError("an image target round-trip preview must end in .png")
+                write_png(decoded[0], preview_path)
+            else:
+                if preview_path.suffix.lower() != ".mp4":
+                    raise ValueError("a video target round-trip preview must end in .mp4")
+                write_mp4(decoded, preview_path, fps=fps)
             logger.info("wrote first-target round-trip preview to %s", args.preview_out)
         logger.info(
             "[%d/%d] encoded %s -> %s",

--- a/vrl/scripts/eval/_score_summary.py
+++ b/vrl/scripts/eval/_score_summary.py
@@ -1,0 +1,152 @@
+"""Shared score aggregation for fixed-prompt checkpoint evaluations.
+
+Every checkpoint eval answers the same statistical question — did this
+checkpoint score better than the base arm on the SAME prompt/seed grid — so
+the distribution, the paired-delta bootstrap, and the scores.jsonl/csv writer
+belong in one place rather than being re-derived per family. ``score_keys`` and
+``base_label`` name report fields rather than the caller, so these stay free
+functions (AGENTS.md placement Rule 1).
+
+The bootstrap RNG is seeded from the report schema plus the label and score
+key, so a rerun over the same rows reproduces the interval exactly.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import math
+import random
+import statistics
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+BOOTSTRAP_RESAMPLES = 2_000
+
+
+def distribution(values: Sequence[float]) -> dict[str, float | int]:
+    """Count/mean/median/std/stderr/min/max for one score column."""
+
+    if not values:
+        raise ValueError("cannot summarize an empty score distribution")
+    std = statistics.pstdev(values) if len(values) > 1 else 0.0
+    return {
+        "count": len(values),
+        "mean": statistics.fmean(values),
+        "median": statistics.median(values),
+        "std": std,
+        "stderr": std / math.sqrt(len(values)),
+        "min": min(values),
+        "max": max(values),
+    }
+
+
+def bootstrap_mean_interval(
+    values: Sequence[float],
+    *,
+    schema: str,
+    label: str,
+    score_key: str,
+) -> tuple[float, float]:
+    """Deterministic percentile bootstrap 95% interval for the mean."""
+
+    seed_bytes = hashlib.sha256(f"{schema}\0{label}\0{score_key}".encode()).digest()
+    rng = random.Random(int.from_bytes(seed_bytes[:8], "big"))
+    means = [
+        statistics.fmean(values[rng.randrange(len(values))] for _ in values)
+        for _ in range(BOOTSTRAP_RESAMPLES)
+    ]
+    means.sort()
+    return means[int(0.025 * (len(means) - 1))], means[int(0.975 * (len(means) - 1))]
+
+
+def summarize_paired_scores(
+    rows: Sequence[dict[str, Any]],
+    *,
+    score_keys: Sequence[str],
+    schema: str,
+    base_label: str = "base",
+    cell_keys: Sequence[str] = ("prompt_index", "sample_index"),
+    unpaired_labels: Sequence[str] = (),
+) -> dict[str, Any]:
+    """Absolute distributions plus per-cell deltas against the base arm.
+
+    The paired statistic is the point of a fixed-prompt eval: comparing
+    independent means across arms would drown the effect in prompt difficulty,
+    which is exactly the variance a shared prompt/seed grid removes. Every arm
+    must therefore cover the identical cell set, and a mismatch is an error
+    rather than a silently smaller comparison.
+
+    ``unpaired_labels`` names arms that are calibration anchors rather than
+    checkpoints (a ground-truth clip set, for instance): they still get an
+    absolute distribution, but they do not share the generated grid and so
+    cannot be differenced against it.
+    """
+
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        grouped.setdefault(str(row["checkpoint_label"]), []).append(row)
+    if base_label not in grouped:
+        raise ValueError(f"paired score summary requires {base_label!r} rows")
+
+    absolute = {
+        label: {key: distribution([float(row[f"r_{key}"]) for row in group]) for key in score_keys}
+        for label, group in grouped.items()
+    }
+
+    def cell_of(row: dict[str, Any]) -> tuple[Any, ...]:
+        return tuple(int(row[name]) for name in cell_keys)
+
+    base = {cell_of(row): row for row in grouped[base_label]}
+    skip = {base_label, *unpaired_labels}
+    paired: dict[str, Any] = {}
+    for label, group in grouped.items():
+        if label in skip:
+            continue
+        cells = {cell_of(row): row for row in group}
+        if set(cells) != set(base):
+            raise ValueError(f"paired score grid differs for {label}")
+        paired[label] = {}
+        for key in score_keys:
+            deltas = [
+                float(cells[cell][f"r_{key}"]) - float(base[cell][f"r_{key}"])
+                for cell in sorted(base)
+            ]
+            lower, upper = bootstrap_mean_interval(
+                deltas,
+                schema=schema,
+                label=label,
+                score_key=key,
+            )
+            paired[label][key] = {
+                **distribution(deltas),
+                "win_rate": sum(delta > 0 for delta in deltas) / len(deltas),
+                "tie_rate": sum(delta == 0 for delta in deltas) / len(deltas),
+                "bootstrap_95ci": [lower, upper],
+                "clear_improvement": lower > 0.0,
+                "clear_regression": upper < 0.0,
+            }
+    return {"absolute": absolute, "paired_delta_from_base": paired}
+
+
+def write_scores(rows: Sequence[dict[str, Any]], output_dir: Path) -> None:
+    """Publish scores.jsonl and scores.csv side by side."""
+
+    with (output_dir / "scores.jsonl").open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+    with (output_dir / "scores.csv").open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=sorted({key for row in rows for key in row}))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+__all__ = [
+    "BOOTSTRAP_RESAMPLES",
+    "bootstrap_mean_interval",
+    "distribution",
+    "summarize_paired_scores",
+    "write_scores",
+]

--- a/vrl/scripts/eval/anima_fixed_eval.py
+++ b/vrl/scripts/eval/anima_fixed_eval.py
@@ -200,6 +200,7 @@ async def _score(
     import torch
     from PIL import Image
 
+    from vrl.config.reward_inference import RewardInferenceConfig
     from vrl.rewards.functions.registry import MultiReward
     from vrl.rewards.types import RewardSample
 
@@ -209,19 +210,25 @@ async def _score(
             "media_type": "image",
             "artifact_format": "tensor",
             "artifact_dir": "outputs/reward_artifacts",
-            "inference": {
-                "kind": "http",
-                "endpoint": endpoint,
-                "timeout_s": 1800,
-                "expected_model": "animereward-quality",
-            },
         }
+    }
+    inference_configs = {
+        "animereward_quality": RewardInferenceConfig(
+            kind="http",
+            endpoint=endpoint,
+            expected_model="animereward-quality",
+        ),
     }
     if with_pickscore:
         components["pickscore"] = 1.0
         kwargs["pickscore"] = {"dtype": "float32"}
+        inference_configs["pickscore"] = RewardInferenceConfig()
 
-    reward = MultiReward.from_dict(components, reward_kwargs=kwargs)
+    reward = MultiReward.from_dict(
+        components,
+        reward_kwargs=kwargs,
+        inference_configs=inference_configs,
+    )
     samples = []
     for row in rows:
         arr = np.asarray(Image.open(row["image_path"]).convert("RGB"), dtype=np.uint8).copy()

--- a/vrl/scripts/eval/cosmos_predict25_kling_eval.py
+++ b/vrl/scripts/eval/cosmos_predict25_kling_eval.py
@@ -402,6 +402,7 @@ def _score_generated_videos(
     artifacts = [
         RewardInferenceArtifact(
             artifact_id=_artifact_id(video),
+            sample_id=_artifact_id(video),
             path=str(video.path),
             prompt=video.prompt,
             metadata={

--- a/vrl/scripts/eval/kling_reward_noise_gate.py
+++ b/vrl/scripts/eval/kling_reward_noise_gate.py
@@ -78,6 +78,7 @@ def _run_shard(args: argparse.Namespace) -> None:
             model(
                 RewardInferenceArtifact(
                     artifact_id=path.stem,
+                    sample_id=path.stem,
                     path=str(path.resolve()),
                     prompt=_PROMPT,
                 ),

--- a/vrl/scripts/eval/sana_aesthetic_checkpoint_eval.py
+++ b/vrl/scripts/eval/sana_aesthetic_checkpoint_eval.py
@@ -505,6 +505,10 @@ def _score_images(
                         f"{image.checkpoint_label}-p{image.prompt_index:04d}"
                         f"-s{image.sample_index:02d}"
                     ),
+                    sample_id=(
+                        f"{image.checkpoint_label}-p{image.prompt_index:04d}"
+                        f"-s{image.sample_index:02d}"
+                    ),
                     path=str(image.path),
                     prompt=image.prompt,
                     metadata={

--- a/vrl/scripts/eval/sana_aesthetic_report.py
+++ b/vrl/scripts/eval/sana_aesthetic_report.py
@@ -79,7 +79,22 @@ def normalize_run_config(cfg: DictConfig) -> DictConfig:
     expected = OmegaConf.to_container(load_config(CANONICAL_CONFIG_NAME), resolve=True)
     if not isinstance(actual, dict) or not isinstance(expected, dict):
         raise TypeError("SANA evaluation configs must resolve to mappings")
-    canonical_digest = _semantic_digest(expected)
+    # The frozen v4 identity predates the parity gate's move out of debug.
+    # Project only that spelling back for hashing: threshold changes and any
+    # additional parity settings must still invalidate the registered protocol.
+    # Runtime validation below keeps the live shape and its mandatory gate.
+    registered_shape = deepcopy(expected)
+    registered_trainer = _section(registered_shape, "trainer")
+    parity = _section(registered_shape, "trainer", "replay_parity")
+    if registered_trainer is not None and parity is not None:
+        debug = _section(registered_shape, "trainer", "debug")
+        if debug is not None and "max_abs_logprob_diff" in parity:
+            if "max_abs_logprob_diff" in debug:
+                raise ValueError("ambiguous SANA parity threshold in debug and replay_parity")
+            debug["max_abs_logprob_diff"] = parity.pop("max_abs_logprob_diff")
+            if not parity:
+                registered_trainer.pop("replay_parity")
+    canonical_digest = _semantic_digest(registered_shape)
     if canonical_digest != CANONICAL_PROTOCOL_SHA256:
         raise ValueError(
             "bundled SANA aesthetic preset changed without a protocol schema update: "
@@ -557,6 +572,15 @@ def _erase_meaningless_spelling(
         return trajectory_storage_policy_from_cfg(value)
 
     trainer = actual.get("trainer")
+    # Historical reports may carry the threshold under debug. This protocol
+    # adapter accepts that old spelling without teaching live training configs
+    # an alias or discarding conflicting/unknown persisted settings.
+    debug = _section(actual, "trainer", "debug")
+    if isinstance(trainer, dict) and debug is not None and "max_abs_logprob_diff" in debug:
+        parity = trainer.setdefault("replay_parity", {})
+        if not isinstance(parity, dict) or "max_abs_logprob_diff" in parity:
+            raise ValueError("ambiguous SANA parity threshold in debug and replay_parity")
+        parity["max_abs_logprob_diff"] = debug.pop("max_abs_logprob_diff")
     uses_retired_entrypoint = (
         isinstance(trainer, dict)
         and trainer.get("entrypoint") == _RETIRED_ENTRYPOINT

--- a/vrl/scripts/eval/unified_reward_robotics_discrimination_probe.py
+++ b/vrl/scripts/eval/unified_reward_robotics_discrimination_probe.py
@@ -86,6 +86,7 @@ async def _score_anchor(
         artifact_id = f"anchor-{anchor_index}:{name}"
         artifact = RewardInferenceArtifact(
             artifact_id=artifact_id,
+            sample_id=artifact_id,
             path=str(path),
             prompt=prompt,
             size_bytes=path.stat().st_size,

--- a/vrl/scripts/eval/video_reward_suite.py
+++ b/vrl/scripts/eval/video_reward_suite.py
@@ -217,6 +217,7 @@ def _score_kling(
         for video in videos:
             artifact = RewardInferenceArtifact(
                 artifact_id=video.stem,
+                sample_id=video.stem,
                 path=str(video),
                 prompt=prompts[video],
             )
@@ -338,6 +339,7 @@ def _score_reward_model(
         for video in videos:
             artifact = RewardInferenceArtifact(
                 artifact_id=video.stem,
+                sample_id=video.stem,
                 path=str(video),
                 prompt=prompts[video],
             )

--- a/vrl/scripts/eval/wan_hpsv3_checkpoint_eval.py
+++ b/vrl/scripts/eval/wan_hpsv3_checkpoint_eval.py
@@ -1,0 +1,444 @@
+"""Fixed-prompt HPSv3 comparison across Wan2.1 T2V LoRA checkpoints.
+
+Online GRPO rotates prompts every update, so ``metrics.csv`` reward is a moving
+target: a batch of hard prompts and a degraded policy look identical there.
+This evaluation freezes the prompt set, the seeds, and the sampling protocol so
+the only thing that varies between arms is the adapter, and reports the PAIRED
+delta against the base arm — the statistic that removes prompt difficulty from
+the comparison.
+
+Two subcommands so a reward-side failure never costs the generation, which is
+the expensive half (81 frames x 20 steps per video):
+
+    generate  base + each checkpoint over the same prompt/seed grid -> mp4s
+    score     HPSv3 over those mp4s -> scores.jsonl/csv + report.json
+
+The base arm is produced by disabling the adapter on the already-built model
+rather than by a second build. That matters for correctness, not just cost: a
+training run's ``resolved_config.yaml`` may carry a warm-start
+``model.lora.path`` (run50 warm-started from an earlier run), so rebuilding
+from that config without overriding the path would silently make "base" the
+warm-start adapter instead of the base model.
+
+All three HPSv3 keys are recorded per video. ``top_frame_mean`` is the training
+objective, but a rising ``top_frame_mean`` beside a falling ``frame_min`` is the
+"best frames improve while the worst rot" reward-hacking signature, and only the
+whole-video keys can show it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import logging
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+from omegaconf import DictConfig, OmegaConf
+
+from vrl.config.loading import load_config
+from vrl.config.precision import resolve_precision_policy
+from vrl.config.schema import parse_config
+from vrl.models.checkpoint_identity import resolve_checkpoint_model_identity
+from vrl.models.families.registry import get_model_family_entry
+from vrl.rewards.inference import RewardInferenceArtifact
+from vrl.scripts.eval._device import resolve_eval_device, resolve_eval_dtype
+from vrl.scripts.eval._sampling import resolve_eval_sampling
+from vrl.scripts.eval._score_summary import summarize_paired_scores, write_scores
+from vrl.scripts.eval.denoise_video_generation import generate_one_video, seed_for
+from vrl.trainers.checkpointing import (
+    is_complete_checkpoint,
+    load_training_checkpoint,
+    read_checkpoint_meta,
+    restore_model_checkpoint,
+    validate_checkpoint_meta_compatibility,
+)
+from vrl.trainers.data import load_prompt_manifest
+from vrl.utils.artifacts import sha256_file
+from vrl.utils.cuda_memory import release_cuda_memory
+from vrl.utils.media import write_mp4
+
+logger = logging.getLogger(__name__)
+
+REPORT_SCHEMA = "vrl.wan_hpsv3_checkpoint_eval/v1"
+BASE_LABEL = "base"
+# Every key the HPSv3 worker returns. The selected training objective is
+# top_frame_mean; the other two exist to expose reward hacking (see module doc).
+SCORE_KEYS = ("top_frame_mean", "frame_mean", "frame_min")
+DEFAULT_BASE_SEED = 2_026_082_500
+
+
+@dataclass(frozen=True, slots=True)
+class CheckpointTarget:
+    """One evaluation arm: a label and the checkpoint it restores (None = base)."""
+
+    label: str
+    path: Path | None
+
+
+@dataclass(frozen=True, slots=True)
+class GeneratedVideo:
+    checkpoint_label: str
+    prompt_index: int
+    sample_index: int
+    seed: int
+    prompt: str
+    path: str
+    size_bytes: int
+    sha256: str
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Compare Wan2.1 T2V LoRA checkpoints on a fixed HPSv3 prompt grid.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    generate = sub.add_parser("generate", help="Generate the fixed prompt/seed grid.")
+    generate.add_argument("--run-dir", type=Path, required=True, help="Training run directory.")
+    generate.add_argument("--output-dir", type=Path, required=True)
+    generate.add_argument(
+        "--checkpoint",
+        action="append",
+        default=[],
+        metavar="[LABEL=]PATH",
+        help="Checkpoint to evaluate; repeatable. Bare paths take the directory name as label.",
+    )
+    generate.add_argument(
+        "--prompts",
+        type=Path,
+        required=True,
+        help="Held-out prompt manifest (.txt or .jsonl), disjoint from the training set.",
+    )
+    generate.add_argument("--limit", type=int, default=24, help="Prompts to take from the head.")
+    generate.add_argument("--samples-per-prompt", type=int, default=2)
+    generate.add_argument("--base-seed", type=int, default=DEFAULT_BASE_SEED)
+    generate.add_argument("--device", default="auto")
+    generate.add_argument(
+        "--no-base",
+        action="store_true",
+        help="Skip the adapter-disabled arm (paired scoring then needs a base elsewhere).",
+    )
+
+    score = sub.add_parser("score", help="Score generated videos with HPSv3.")
+    score.add_argument("--run-dir", type=Path, required=True)
+    score.add_argument("--output-dir", type=Path, required=True)
+    score.add_argument("--device", default="auto")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    args = build_parser().parse_args(argv)
+    result = generate_grid(args) if args.command == "generate" else score_grid(args)
+    json.dump(result, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+
+
+# --- generate -----------------------------------------------------------------
+
+
+def generate_grid(args: argparse.Namespace) -> dict[str, Any]:
+    if args.limit < 1 or args.samples_per_prompt < 1:
+        raise ValueError("--limit and --samples-per-prompt must be >= 1")
+    targets = _parse_targets(args.checkpoint)
+    if not targets and args.no_base:
+        raise ValueError("nothing to generate: pass --checkpoint or drop --no-base")
+
+    cfg = _load_run_config(args.run_dir)
+    root = parse_config(cfg)
+    device = resolve_eval_device(args.device)
+    precision = resolve_precision_policy(root)
+    dtype = resolve_eval_dtype(
+        "auto",
+        root,
+        precision=precision,
+        device=device,
+        requires_trainer="Wan HPSv3 checkpoint evaluation",
+    )
+    entry = get_model_family_entry(str(root.model.family))
+    build = entry.resolve_model_build(
+        root,
+        device,
+        precision=precision,
+        parameter_dtype_override=dtype,
+    )
+    identity = resolve_checkpoint_model_identity(build)
+
+    # Preflight every checkpoint against the runtime identity BEFORE paying for
+    # model construction: a mismatched arm should fail in seconds, not after the
+    # pipeline is resident on the GPU.
+    for target in targets:
+        if target.path is None:
+            continue
+        if not is_complete_checkpoint(target.path):
+            raise ValueError(f"incomplete checkpoint: {target.path}")
+        validate_checkpoint_meta_compatibility(
+            read_checkpoint_meta(target.path),
+            family=entry.family,
+            expected_model_identity=identity,
+            strict=True,
+        )
+
+    examples = load_prompt_manifest(args.prompts)[: args.limit]
+    if len(examples) < args.limit:
+        raise ValueError(f"manifest has {len(examples)} prompts, fewer than --limit {args.limit}")
+    sampling = resolve_eval_sampling(cfg)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    bundle = entry.build_rollout(build)
+    model = bundle.model.eval()
+    videos: list[GeneratedVideo] = []
+    try:
+        # Base FIRST, while no checkpoint has been restored. Ordering is the
+        # guarantee: once a checkpoint is loaded, "adapter disabled" no longer
+        # means the base model for any later arm.
+        if not args.no_base:
+            with model.disable_adapter():
+                videos += _generate_arm(model, BASE_LABEL, examples, sampling, args)
+        for target in targets:
+            restore_model_checkpoint(
+                load_training_checkpoint(target.path),
+                bundle=bundle,
+                family=entry.family,
+                expected_model_identity=identity,
+                strict=True,
+            )
+            videos += _generate_arm(model, target.label, examples, sampling, args)
+    finally:
+        del model, bundle
+        release_cuda_memory()
+
+    _write_jsonl(args.output_dir / "generated.jsonl", [_row_of(video) for video in videos])
+    provenance = {
+        "schema": REPORT_SCHEMA,
+        "run_dir": str(args.run_dir),
+        "resolved_config_sha256": sha256_file(args.run_dir / "resolved_config.yaml"),
+        "prompts": str(args.prompts),
+        "limit": args.limit,
+        "samples_per_prompt": args.samples_per_prompt,
+        "base_seed": args.base_seed,
+        "seed_formula": "base_seed + prompt_index * samples_per_prompt + sample_index",
+        "sampling": sampling,
+        "arms": [BASE_LABEL] * (not args.no_base) + [target.label for target in targets],
+        "checkpoints": {
+            target.label: {
+                "path": str(target.path),
+                "meta": read_checkpoint_meta(target.path),
+            }
+            for target in targets
+        },
+    }
+    _write_json(args.output_dir / "provenance.json", provenance)
+    return {"videos": len(videos), "arms": provenance["arms"], "output_dir": str(args.output_dir)}
+
+
+def _generate_arm(
+    model: Any,
+    label: str,
+    examples: list[Any],
+    sampling: dict[str, Any],
+    args: argparse.Namespace,
+) -> list[GeneratedVideo]:
+    arm_dir = args.output_dir / "videos" / label
+    arm_dir.mkdir(parents=True, exist_ok=True)
+    produced: list[GeneratedVideo] = []
+    for prompt_index, example in enumerate(examples):
+        for sample_index in range(args.samples_per_prompt):
+            seed = seed_for(
+                base_seed=args.base_seed,
+                prompt_index=prompt_index,
+                sample_index=sample_index,
+                samples_per_prompt=args.samples_per_prompt,
+            )
+            video = generate_one_video(
+                model,
+                prompt=example.prompt,
+                seed=seed,
+                sampling=sampling,
+            )
+            # A silently broken adapter yields constant frames that still score.
+            # Refuse here rather than spend reward GPU-hours scoring noise.
+            if not bool(torch.isfinite(video).all()) or float(video.float().std()) < 1e-3:
+                raise RuntimeError(
+                    f"degenerate video for {label} prompt {prompt_index} sample {sample_index}",
+                )
+            path = arm_dir / f"p{prompt_index:04d}_s{sample_index:02d}.mp4"
+            write_mp4(video, path, fps=float(sampling["fps"]))
+            produced.append(
+                GeneratedVideo(
+                    checkpoint_label=label,
+                    prompt_index=prompt_index,
+                    sample_index=sample_index,
+                    seed=seed,
+                    prompt=example.prompt,
+                    path=str(path),
+                    size_bytes=path.stat().st_size,
+                    sha256=sha256_file(path),
+                ),
+            )
+        logger.info("%s: %d/%d prompts", label, prompt_index + 1, len(examples))
+    return produced
+
+
+# --- score --------------------------------------------------------------------
+
+
+def score_grid(args: argparse.Namespace) -> dict[str, Any]:
+    from vrl.rewards.models.hpsv3 import HPSv3Model
+
+    rows = _read_jsonl(args.output_dir / "generated.jsonl")
+    if not rows:
+        raise ValueError(f"no generated.jsonl rows under {args.output_dir}")
+    device = resolve_eval_device(args.device)
+    worker_config = _hpsv3_worker_config(_load_run_config(args.run_dir), device=device)
+
+    model = HPSv3Model(worker_config)
+    scored: list[dict[str, Any]] = []
+    try:
+        for row in rows:
+            path = Path(row["path"])
+            # The grid is the contract: a video edited or lost between generate
+            # and score would silently compare two different things.
+            if sha256_file(path) != row["sha256"]:
+                raise ValueError(f"video changed since generation: {path}")
+            scores = model(
+                RewardInferenceArtifact(
+                    artifact_id=f"{row['checkpoint_label']}-p{row['prompt_index']:04d}"
+                    f"-s{row['sample_index']:02d}",
+                    sample_id=f"{row['checkpoint_label']}-p{row['prompt_index']:04d}"
+                    f"-s{row['sample_index']:02d}",
+                    path=str(path),
+                    prompt=str(row["prompt"]),
+                    size_bytes=int(row["size_bytes"]),
+                    sha256=str(row["sha256"]),
+                ),
+            )
+            missing = [key for key in SCORE_KEYS if key not in scores]
+            if missing:
+                raise ValueError(f"HPSv3 returned no {missing} for {path}")
+            scored.append(
+                {**row, **{f"r_{key}": float(scores[key]) for key in SCORE_KEYS}},
+            )
+    finally:
+        del model
+        release_cuda_memory()
+
+    write_scores(scored, args.output_dir)
+    summary = summarize_paired_scores(
+        scored,
+        score_keys=SCORE_KEYS,
+        schema=REPORT_SCHEMA,
+        base_label=BASE_LABEL,
+    )
+    report = {"schema": REPORT_SCHEMA, "scored": len(scored), **summary}
+    _write_json(args.output_dir / "report.json", report)
+    return report
+
+
+def _hpsv3_worker_config(cfg: DictConfig, *, device: torch.device) -> dict[str, Any]:
+    """Project the run's own reward block so eval scores on training's terms.
+
+    ``resolve=True`` keeps an unresolved ``${...}`` literal from reaching the
+    reward loader, which is why the raw subtree is never passed through.
+    """
+
+    selected = OmegaConf.select(cfg, "reward.kwargs.hpsv3", default={})
+    reward_cfg = OmegaConf.to_container(selected, resolve=True) or {}
+    if not isinstance(reward_cfg, dict):
+        raise ValueError("reward.kwargs.hpsv3 must be a mapping")
+    worker_config = dict(reward_cfg.get("worker_config") or {})
+    worker_config.setdefault(
+        "reward_model_name",
+        str(reward_cfg.get("reward_name") or "MizzenAI/HPSv3@main"),
+    )
+    worker_config["device"] = str(device)
+    return worker_config
+
+
+# --- shared -------------------------------------------------------------------
+
+
+def _load_run_config(run_dir: Path) -> DictConfig:
+    """Load the run's resolved config with the eval-only overrides applied.
+
+    ``model.lora.path`` is cleared because a warm-started run records its
+    donor adapter there, and every arm here supplies its own weights (base by
+    disabling the adapter, checkpoints by restoring state). Compile is off so
+    the comparison is not also a kernel comparison.
+    """
+
+    # An absolute Path, not a string: load_config resolves a relative string
+    # against the bundled preset tree.
+    path = (run_dir / "resolved_config.yaml").expanduser().resolve()
+    if not path.is_file():
+        raise FileNotFoundError(f"run directory has no resolved_config.yaml: {run_dir}")
+    cfg = load_config(
+        path,
+        overrides=["model.lora.path=", "model.torch_compile.enable=false"],
+    )
+    # The registry resolves the config's family alias (a run records "wan"),
+    # so the canonical entry name is what this check can trust.
+    entry = get_model_family_entry(str(OmegaConf.select(cfg, "model.family", default="")))
+    if entry.family != "wan_2_1":
+        raise ValueError(f"this evaluation requires a wan_2_1 run; got {entry.family!r}")
+    return cfg
+
+
+def _parse_targets(values: list[str]) -> list[CheckpointTarget]:
+    targets = [_parse_target(value) for value in values]
+    labels = [target.label for target in targets]
+    if len(set(labels)) != len(labels):
+        raise ValueError(f"checkpoint labels must be unique: {labels}")
+    if BASE_LABEL in labels:
+        raise ValueError(f"{BASE_LABEL!r} is reserved for the adapter-disabled arm")
+    return targets
+
+
+def _parse_target(value: str) -> CheckpointTarget:
+    text = str(value).strip()
+    if not text:
+        raise ValueError("--checkpoint values must be non-empty")
+    if "=" in text:
+        raw_label, raw_path = text.split("=", 1)
+        path = Path(raw_path).expanduser().resolve()
+    else:
+        path = Path(text).expanduser().resolve()
+        raw_label = path.parent.name if path.name == "checkpoint-final" else path.name
+    label = re.sub(r"[^A-Za-z0-9_.-]+", "_", raw_label.strip()).strip("._-")
+    if not label:
+        raise ValueError(f"checkpoint label resolved empty for {value!r}")
+    if not path.is_dir():
+        raise FileNotFoundError(f"checkpoint path does not exist: {path}")
+    return CheckpointTarget(label=label, path=path)
+
+
+def _row_of(video: GeneratedVideo) -> dict[str, Any]:
+    return asdict(video)
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+    with path.open(encoding="utf-8") as handle:
+        return [json.loads(line) for line in handle if line.strip()]
+
+
+if __name__ == "__main__":
+    with contextlib.suppress(KeyboardInterrupt):
+        main()

--- a/vrl/scripts/eval/wan_robotics_checkpoint_eval.py
+++ b/vrl/scripts/eval/wan_robotics_checkpoint_eval.py
@@ -16,8 +16,6 @@ import json
 import logging
 import math
 import os
-import random
-import statistics
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
@@ -35,6 +33,7 @@ from vrl.rewards.models.robotics_video_reward import RoboticsVideoRewardModel
 from vrl.scripts.data.common import write_jsonl
 from vrl.scripts.eval._device import resolve_eval_device
 from vrl.scripts.eval._sampling import resolve_eval_sampling
+from vrl.scripts.eval._score_summary import summarize_paired_scores
 from vrl.scripts.eval.denoise_video_generation import generate_one_video
 from vrl.trainers.checkpointing import (
     TRAINING_CHECKPOINT_NAME,
@@ -55,7 +54,6 @@ REPORT_SCHEMA_VERSION = 1
 DEFAULT_TARGETS = ("base", "5", "10", "15", "20")
 DEFAULT_BASE_SEED = 2_026_072_200
 DEFAULT_SEED_STRIDE = 1_000
-BOOTSTRAP_RESAMPLES = 2_000
 SCORE_KEYS = (
     "robotics_blend",
     "target_dino_similarity",
@@ -655,6 +653,10 @@ def _build_scoring_artifacts(
                 f"{row['checkpoint_label']}-r{int(row['row_index']):04d}"
                 f"-s{int(row['sample_index']):02d}"
             ),
+            sample_id=(
+                f"{row['checkpoint_label']}-r{int(row['row_index']):04d}"
+                f"-s{int(row['sample_index']):02d}"
+            ),
             path=str(path),
             prompt=str(row["prompt"]),
             size_bytes=int(row["bytes"]),
@@ -681,6 +683,7 @@ def _build_scoring_artifacts(
             artifacts.append(
                 RewardInferenceArtifact(
                     artifact_id=f"reference-r{int(selected['row_index']):04d}",
+                    sample_id=f"reference-r{int(selected['row_index']):04d}",
                     path=str(target_path),
                     prompt=str(selected["prompt"]),
                     size_bytes=target_path.stat().st_size,
@@ -722,86 +725,26 @@ def _reward_worker_config(cfg: DictConfig, *, device: torch.device) -> dict[str,
 
 
 def summarize_scores(rows: list[dict[str, Any]]) -> dict[str, Any]:
-    """Summarize absolute scores and paired checkpoint deltas from the base grid."""
+    """Summarize absolute scores and paired checkpoint deltas from the base grid.
 
-    grouped: dict[str, list[dict[str, Any]]] = {}
-    for row in rows:
-        grouped.setdefault(str(row["checkpoint_label"]), []).append(row)
-    absolute: dict[str, Any] = {}
-    for label, group in grouped.items():
-        absolute[label] = {
-            key: _distribution([float(row[f"r_{key}"]) for row in group]) for key in SCORE_KEYS
-        }
+    ``reference`` is a ground-truth calibration arm, not a checkpoint: it is
+    scored absolutely but never differenced, because its rows do not share the
+    generated grid.
+    """
 
-    base = {
-        (int(row["row_index"]), int(row["sample_index"])): row for row in grouped.get("base", [])
-    }
-    if not base:
-        raise ValueError("paired score summary requires base rows")
-    paired: dict[str, Any] = {}
-    for label, group in grouped.items():
-        if label in {"base", "reference"}:
-            continue
-        cells = {(int(row["row_index"]), int(row["sample_index"])): row for row in group}
-        if set(cells) != set(base):
-            raise ValueError(f"paired score grid differs for {label}")
-        paired[label] = {}
-        for key in SCORE_KEYS:
-            deltas = [
-                float(cells[cell][f"r_{key}"]) - float(base[cell][f"r_{key}"])
-                for cell in sorted(base)
-            ]
-            lower, upper = _bootstrap_mean_interval(deltas, label=label, score_key=key)
-            paired[label][key] = {
-                **_distribution(deltas),
-                "win_rate": sum(delta > 0 for delta in deltas) / len(deltas),
-                "tie_rate": sum(delta == 0 for delta in deltas) / len(deltas),
-                "bootstrap_95ci": [lower, upper],
-                "clear_improvement": lower > 0.0,
-            }
-
-    checkpoint_labels = [label for label in grouped if label not in {"base", "reference"}]
+    summary = summarize_paired_scores(
+        rows,
+        score_keys=SCORE_KEYS,
+        schema=REPORT_SCHEMA,
+        cell_keys=("row_index", "sample_index"),
+        unpaired_labels=("reference",),
+    )
+    absolute = summary["absolute"]
     best_label = max(
-        ["base", *checkpoint_labels],
+        [label for label in absolute if label != "reference"],
         key=lambda label: float(absolute[label]["robotics_blend"]["mean"]),
     )
-    return {
-        "absolute": absolute,
-        "paired_delta_from_base": paired,
-        "best_mean_robotics_blend": best_label,
-    }
-
-
-def _distribution(values: list[float]) -> dict[str, float | int]:
-    if not values:
-        raise ValueError("cannot summarize an empty score distribution")
-    std = statistics.pstdev(values) if len(values) > 1 else 0.0
-    return {
-        "count": len(values),
-        "mean": statistics.fmean(values),
-        "median": statistics.median(values),
-        "std": std,
-        "stderr": std / math.sqrt(len(values)),
-        "min": min(values),
-        "max": max(values),
-    }
-
-
-def _bootstrap_mean_interval(
-    values: list[float],
-    *,
-    label: str,
-    score_key: str,
-) -> tuple[float, float]:
-    seed_bytes = hashlib.sha256(f"{REPORT_SCHEMA}\0{label}\0{score_key}".encode()).digest()
-    rng = random.Random(int.from_bytes(seed_bytes[:8], "big"))
-    means = []
-    for _ in range(BOOTSTRAP_RESAMPLES):
-        means.append(statistics.fmean(values[rng.randrange(len(values))] for _ in values))
-    means.sort()
-    lower_index = int(0.025 * (len(means) - 1))
-    upper_index = int(0.975 * (len(means) - 1))
-    return means[lower_index], means[upper_index]
+    return {**summary, "best_mean_robotics_blend": best_label}
 
 
 def _json_sha256(value: Any) -> str:

--- a/vrl/scripts/supervise.py
+++ b/vrl/scripts/supervise.py
@@ -44,7 +44,7 @@ from typing import TYPE_CHECKING, Any
 from vrl.trainers.metrics_io import online_metric_columns
 
 if TYPE_CHECKING:
-    from vrl.trainers.core.types import DebugConfig, RolloutOrchestrationConfig
+    from vrl.trainers.core.types import ReplayParityConfig, RolloutOrchestrationConfig
 
 from vrl.scripts.train import RUN_VERDICT_NAME, rank_run_verdict_name
 
@@ -143,6 +143,12 @@ class HealthGateConfig:
     continuous: ContinuousHealthPolicy | None = None
     min_reward_std: float = 1e-4
     min_grad_norm: float = 1e-8
+    # A pre-clip gradient-norm spike is the earliest observable signal of a
+    # diverging full-parameter update: the norm leaves its steady band one epoch
+    # before loss/reward go non-finite, so catching it here saves the run's last
+    # trustworthy checkpoint. Left at inf (disabled) because the healthy band is
+    # recipe-specific; an operator sets it from the run's own observed range.
+    max_grad_norm: float = math.inf
 
     def __post_init__(self) -> None:
         required_columns = set(_REQUIRED_HEALTH_METRICS)
@@ -165,6 +171,14 @@ class HealthGateConfig:
         ):
             if not math.isfinite(getattr(self, name)) or getattr(self, name) < 0:
                 raise ValueError(f"{name} must be finite and >= 0")
+        # Validated apart from the loop above: inf is this field's "disabled".
+        if math.isnan(self.max_grad_norm) or self.max_grad_norm <= 0:
+            raise ValueError("max_grad_norm must be > 0")
+        if self.max_grad_norm <= self.min_grad_norm:
+            raise ValueError(
+                f"max_grad_norm must be > min_grad_norm "
+                f"({self.max_grad_norm:g} <= {self.min_grad_norm:g})",
+            )
 
     @classmethod
     def from_cli(
@@ -172,7 +186,7 @@ class HealthGateConfig:
         args: argparse.Namespace,
         *,
         schedule: RolloutOrchestrationConfig,
-        debug: DebugConfig,
+        replay_parity: ReplayParityConfig,
     ) -> HealthGateConfig:
         """Reconcile operator CLI thresholds against the resolved training config.
 
@@ -209,8 +223,14 @@ class HealthGateConfig:
             )
 
         parity_limit = args.health_max_pre_update_logprob_diff
+        training_parity_limit = float(replay_parity.max_abs_logprob_diff)
         if parity_limit is None:
-            parity_limit = float(debug.max_abs_logprob_diff)
+            parity_limit = training_parity_limit
+        elif parity_limit > training_parity_limit:
+            raise ValueError(
+                "health max_pre_update_logprob_diff cannot exceed the training "
+                f"replay-parity limit ({parity_limit:g} > {training_parity_limit:g})",
+            )
 
         return cls(
             poll_seconds=args.health_poll_seconds,
@@ -219,6 +239,7 @@ class HealthGateConfig:
             continuous=continuous,
             min_reward_std=args.health_min_reward_std,
             min_grad_norm=args.health_min_grad_norm,
+            max_grad_norm=args.health_max_grad_norm,
         )
 
 
@@ -394,6 +415,10 @@ class MetricsHealthGate:
             reasons.append(
                 f"grad_norm {grad_norm:g} is below minimum {self.config.min_grad_norm:g}",
             )
+        if grad_norm is not None and grad_norm > self.config.max_grad_norm:
+            reasons.append(
+                f"grad_norm {grad_norm:g} is above maximum {self.config.max_grad_norm:g}",
+            )
         return reasons, parsed
 
     def _write_verdict(
@@ -427,6 +452,11 @@ class MetricsHealthGate:
                 ),
                 "min_reward_std": self.config.min_reward_std,
                 "min_grad_norm": self.config.min_grad_norm,
+                # None, not inf: the verdict is a machine-readable contract and
+                # ``Infinity`` is not valid JSON for a non-Python reader.
+                "max_grad_norm": (
+                    None if math.isinf(self.config.max_grad_norm) else self.config.max_grad_norm
+                ),
             },
         }
         path = self.output_dir / HEALTH_VERDICT_NAME
@@ -868,7 +898,8 @@ def build_parser() -> argparse.ArgumentParser:
         type=_bounded_number(float, 0),
         default=None,
         help="Maximum healthy pre-update log-probability difference. When omitted, "
-        "derive trainer.debug.max_abs_logprob_diff from the resolved training config.",
+        "derive trainer.replay_parity.max_abs_logprob_diff from the resolved "
+        "training config. An override may tighten, but not widen, that limit.",
     )
     parser.add_argument(
         "--health-max-stale-policy-versions",
@@ -900,9 +931,16 @@ def build_parser() -> argparse.ArgumentParser:
         help=f"Minimum healthy gradient norm (default: {health_defaults.min_grad_norm:g}).",
     )
     parser.add_argument(
+        "--health-max-grad-norm",
+        type=_bounded_number(float, 0, exclusive=True),
+        default=health_defaults.max_grad_norm,
+        help="Maximum healthy PRE-CLIP gradient norm; a spike above the run's steady "
+        "band is the earliest warning of a diverging update (default: disabled).",
+    )
+    parser.add_argument(
         "overrides",
         nargs="*",
-        help="OmegaConf dotlist overrides forwarded to vrl-train.",
+        help="Ordered +group=option presets and dotlist overrides forwarded to vrl-train.",
     )
     return parser
 
@@ -950,7 +988,7 @@ def main(argv: list[str] | None = None) -> None:
             health = HealthGateConfig.from_cli(
                 args,
                 schedule=trainer.rollout_orchestration,
-                debug=trainer.debug,
+                replay_parity=trainer.replay_parity,
             )
         except (TypeError, ValueError) as error:
             parser.error(str(error))

--- a/vrl/scripts/train.py
+++ b/vrl/scripts/train.py
@@ -1,9 +1,9 @@
 """Unified YAML-driven training entry point.
 
-The experiment name and implementation entrypoint belong in the bundled
-``vrl/config/presets/experiment/**/*.yaml`` files. This module is only the
-CLI/import layer: it loads one YAML config, imports ``trainer.entrypoint``, then
-runs it.
+Execution recipes declare ``trainer.entrypoint``. Independent model, reward,
+and dataset presets can be composed at launch with ``+group=option`` arguments.
+This module is only the CLI/import layer: it loads the composed config, imports
+the entrypoint, then runs it.
 """
 
 from __future__ import annotations
@@ -184,7 +184,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "overrides",
         nargs="*",
-        help="OmegaConf dotlist overrides, e.g. trainer.seed=42 actor.optim.lr=2e-4",
+        help=(
+            "Ordered preset overlays (+reward=ocr +dataset=...) and OmegaConf "
+            "dotlist overrides (trainer.seed=42 actor.optim.lr=2e-4)."
+        ),
     )
     return parser
 

--- a/vrl/trainers/core/types.py
+++ b/vrl/trainers/core/types.py
@@ -10,6 +10,7 @@ default is the single copy (base YAML must not restate it).
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 
 
@@ -47,13 +48,22 @@ class EMAConfig:
 class DebugConfig:
     """Diagnostic toggles consumed by the trainer."""
 
-    # First-step log-prob round-trip check (collected old_lp vs fresh_lp).
+    # Rich first-step provenance for rollout/replay diagnosis and NFT probes.
     first_step: bool = field(default=False)
+
+
+@dataclass(slots=True)
+class ReplayParityConfig:
+    """Mandatory unchanged-policy rollout/replay parity threshold."""
+
     max_abs_logprob_diff: float = field(default=0.01)
 
     def __post_init__(self) -> None:
-        if float(self.max_abs_logprob_diff) < 0:
-            raise ValueError("trainer.debug.max_abs_logprob_diff must be >= 0")
+        limit = float(self.max_abs_logprob_diff)
+        if not math.isfinite(limit) or limit < 0:
+            raise ValueError(
+                "trainer.replay_parity.max_abs_logprob_diff must be finite and >= 0",
+            )
 
 
 @dataclass(slots=True)

--- a/vrl/trainers/data/prompts.py
+++ b/vrl/trainers/data/prompts.py
@@ -24,15 +24,16 @@ class PromptExample:
     target_text: str = ""
     reference_image: str | None = field(default=None, metadata={"artifact": True})
     reference_video: str | None = field(default=None, metadata={"artifact": True})
+    # CONTRACT: clean targets stay manifest-relative for the whole run. Exactly
+    # one target_image/target_video is the identity key into sft-latents shards;
+    # target-similarity rewards resolve the same artifact per process. Load-time
+    # reference resolution must never rewrite either target identity.
     target_image: str | None = field(default=None, metadata={"artifact": True})
-    # CONTRACT: target_video stays manifest-relative for the whole run — it is
-    # the identity key into sft-latents shards (save/load_sft_latents) and into
-    # target-similarity rewards, which resolve it per-process themselves.
-    # Load-time resolution (``resolve_prompt_example_references``) covers REFERENCE
-    # fields only and must never rewrite this one.
     target_video: str | None = field(default=None, metadata={"artifact": True})
     references: list[str] = field(default_factory=list, metadata={"artifact": True})
-    task_type: str = "text_to_video"
+    # Empty delegates the modality to the selected model-family registry entry.
+    # A video default silently mislabeled image-family JSONL rows such as Anima.
+    task_type: str = ""
     request_overrides: dict[str, Any] = field(default_factory=dict)
     metadata: dict[str, Any] = field(default_factory=dict)
 
@@ -80,7 +81,7 @@ def load_prompt_manifest(path: str | Path) -> list[PromptExample]:
     """
     p = Path(path)
     if p.suffix == ".jsonl":
-        return list(JsonlPromptDataset(p).examples)
+        return load_prompt_examples_from_jsonl_bytes(p.read_bytes(), source=p)
     if p.suffix == ".txt":
         examples: list[PromptExample] = []
         with p.open(encoding="utf-8") as f:
@@ -93,6 +94,48 @@ def load_prompt_manifest(path: str | Path) -> list[PromptExample]:
                 examples.append(PromptExample(prompt=line, target_text=target))
         return examples
     raise ValueError(f"Unsupported manifest suffix: {p.suffix}")
+
+
+def load_prompt_examples_from_jsonl_bytes(
+    payload: bytes,
+    *,
+    source: str | Path = "<prompt manifest>",
+) -> list[PromptExample]:
+    """Parse an immutable UTF-8 JSONL snapshot into prompt examples.
+
+    Callers that already authenticated manifest bytes can pass that exact
+    snapshot through training without reopening a mutable filesystem path.
+    Unknown row fields retain the native manifest behavior: they are merged
+    into ``PromptExample.metadata`` after any explicit metadata entries.
+    """
+
+    if type(payload) is not bytes:
+        raise TypeError("prompt manifest payload must be immutable bytes")
+    context = str(source)
+    try:
+        text = payload.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ValueError(f"{context}: prompt manifest must be valid UTF-8") from error
+
+    examples: list[PromptExample] = []
+    known_fields = set(PromptExample.__dataclass_fields__)
+    for line_number, line in enumerate(text.splitlines(), 1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise ValueError(f"{context}:{line_number}: invalid JSON") from error
+        if not isinstance(obj, dict):
+            raise ValueError(f"{context}:{line_number}: JSONL rows must be objects")
+        extra_metadata = {key: value for key, value in obj.items() if key not in known_fields}
+        prompt_fields = {key: value for key, value in obj.items() if key in known_fields}
+        metadata = dict(prompt_fields.get("metadata") or {})
+        metadata.update(extra_metadata)
+        prompt_fields["metadata"] = metadata
+        examples.append(PromptExample(**prompt_fields))
+    return examples
 
 
 def load_prompt_mixture(
@@ -198,24 +241,11 @@ class JsonlPromptDataset(Dataset):
     """
 
     def __init__(self, path: str | Path) -> None:
-        self.examples: list[PromptExample] = []
-        known_fields = set(PromptExample.__dataclass_fields__)
-        with open(path) as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                obj = json.loads(line)
-                if not isinstance(obj, dict):
-                    raise ValueError(f"{path}: JSONL rows must be objects")
-                extra_metadata = {
-                    key: value for key, value in obj.items() if key not in known_fields
-                }
-                prompt_fields = {key: value for key, value in obj.items() if key in known_fields}
-                metadata = dict(prompt_fields.get("metadata") or {})
-                metadata.update(extra_metadata)
-                prompt_fields["metadata"] = metadata
-                self.examples.append(PromptExample(**prompt_fields))
+        manifest_path = Path(path)
+        self.examples = load_prompt_examples_from_jsonl_bytes(
+            manifest_path.read_bytes(),
+            source=manifest_path,
+        )
 
     def __len__(self) -> int:
         return len(self.examples)
@@ -318,6 +348,7 @@ __all__ = [
     "JsonlPromptDataset",
     "PromptExample",
     "load_prompt_examples_from_config",
+    "load_prompt_examples_from_jsonl_bytes",
     "load_prompt_image_manifest",
     "load_prompt_manifest",
     "load_prompt_mixture",

--- a/vrl/trainers/data/sft_latents.py
+++ b/vrl/trainers/data/sft_latents.py
@@ -1,6 +1,6 @@
 """Clean-latents shard I/O for the GRPO diffusion-loss regularizer.
 
-One on-disk contract: ``{target_video -> [C, T, H, W] VAE latents}`` plus the
+One on-disk contract: ``{target artifact -> [C, T, H, W] VAE latents}`` plus the
 family/model provenance needed to reject a shard encoded with a different model.
 The producer is ``vrl/scripts/denoise/encode_targets.py``; the consumer is
 ``run_online_recipe`` (via ``data.sft_latents``) when ``algorithm.sft_weight > 0``.
@@ -12,10 +12,53 @@ symbol, constant, or helper with the manifest code.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from vrl.trainers.data.prompts import PromptExample
 
 SFT_LATENTS_SCHEMA_VERSION = 2
+
+
+@dataclass(frozen=True, slots=True)
+class CleanTargetRef:
+    """Stable manifest identity and media kind for one clean target."""
+
+    field: Literal["target_image", "target_video"]
+    key: str
+
+
+def resolve_clean_target(source: Mapping[str, object] | PromptExample) -> CleanTargetRef:
+    """Resolve the one clean target shared by the shard producer and consumer.
+
+    ``source`` is either a typed ``PromptExample`` or rollout metadata received
+    across the collector boundary. Requiring exactly one field prevents a shard
+    from being encoded under one identity and looked up under another.
+    """
+
+    candidates = (
+        (
+            ("target_image", source.get("target_image")),
+            ("target_video", source.get("target_video")),
+        )
+        if isinstance(source, Mapping)
+        else (("target_image", source.target_image), ("target_video", source.target_video))
+    )
+    targets = [
+        CleanTargetRef(field=field, key=str(value).strip())
+        for field, value in candidates
+        if value is not None and str(value).strip()
+    ]
+    if len(targets) != 1:
+        present = [target.field for target in targets]
+        raise ValueError(
+            "the diffusion regularizer requires exactly one clean target field "
+            f"(target_image or target_video); found {present}",
+        )
+    return targets[0]
 
 
 def save_sft_latents(
@@ -28,7 +71,7 @@ def save_sft_latents(
 ) -> None:
     """Write the clean-latents shard the GRPO diffusion-loss regularizer reads.
 
-    One file, one contract: ``{target_video -> [C, T, H, W] VAE latents}``
+    One file, one contract: ``{target artifact -> [C, T, H, W] VAE latents}``
     plus the provenance needed to reject a shard encoded with a different
     family or model. The producer is
     ``vrl/scripts/denoise/encode_targets.py``.
@@ -107,6 +150,8 @@ def load_sft_latents(
 
 __all__ = [
     "SFT_LATENTS_SCHEMA_VERSION",
+    "CleanTargetRef",
     "load_sft_latents",
+    "resolve_clean_target",
     "save_sft_latents",
 ]

--- a/vrl/trainers/online/config.py
+++ b/vrl/trainers/online/config.py
@@ -12,6 +12,7 @@ from vrl.trainers.core.types import (
     EMAConfig,
     OptimConfig,
     PrecisionDriftGuardConfig,
+    ReplayParityConfig,
     RolloutOrchestrationConfig,
 )
 from vrl.utils.config import require_exact_int
@@ -181,6 +182,10 @@ class TrainerConfig:
     debug: DebugConfig = field(
         default_factory=DebugConfig,
         metadata={"yaml": "trainer.debug"},
+    )
+    replay_parity: ReplayParityConfig = field(
+        default_factory=ReplayParityConfig,
+        metadata={"yaml": "trainer.replay_parity"},
     )
     precision_drift_guard: PrecisionDriftGuardConfig = field(
         default_factory=PrecisionDriftGuardConfig,

--- a/vrl/trainers/online/precision_guard.py
+++ b/vrl/trainers/online/precision_guard.py
@@ -2,8 +2,8 @@
 
 When rollout and replay use different role precision policies, the collection
 time logprob no longer equals the freshly recomputed replay logprob, so the GRPO
-importance ratio is != 1 at the very first step. This guard recomputes parity on
-the first training step (before any optimizer update) and either warns or fails,
+importance ratio is != 1 at the first real update. This guard recomputes parity
+before that optimizer update and either warns or fails,
 using the shared :func:`compute_logprob_mismatch_stats`.
 
 It is the enforcement side of the same fact the per-step mismatch metrics (P1)
@@ -139,7 +139,7 @@ def measure_precision_drift(
     evaluate_fn: Callable[[int], Any],
     metadata: Mapping[str, Any] | None = None,
 ) -> dict[str, Any] | None:
-    """Measure first-step precision drift without choosing process-wide failure.
+    """Measure first-update precision drift without choosing process-wide failure.
 
     ``evaluate_fn(timestep_idx)`` returns a ``TrajectorySignalBatch``-like object with
     ``.primary.log_prob`` (fresh replay) and ``.primary.old_log_prob`` (rollout

--- a/vrl/trainers/online/trainer.py
+++ b/vrl/trainers/online/trainer.py
@@ -18,7 +18,7 @@ import torch
 import torch.nn as nn
 
 from vrl.algorithms.advantages import all_reduce_sufficient_stats
-from vrl.algorithms.base import Algorithm
+from vrl.algorithms.base import Algorithm, ComponentAdvantageAlgorithm
 from vrl.algorithms.logprob_mismatch import (
     LogprobMismatchStats,
     compute_logprob_mismatch_stats,
@@ -700,7 +700,7 @@ class OnlineTrainer:
         # (importance-ratio algorithms hold a `precision_correction` slot).
         if hasattr(algorithm, "precision_correction"):
             algorithm.precision_correction = config.precision_correction
-        # Clean fine-tuning latents ({target_video -> [C,T,H,W]}) for the GRPO
+        # Clean fine-tuning latents ({target artifact -> [C,T,H,W]}) for the GRPO
         # diffusion-loss regularizer; the recipe loads data.sft_latents and the
         # config layer already rejected sft_weight>0 without it.
         self._sft_latents = dict(sft_latents) if sft_latents else None
@@ -748,6 +748,12 @@ class OnlineTrainer:
         self._optimizer: torch.optim.Optimizer | None = None
         self._ema: EMAModuleWrapper | None = None
         self._rollout_weights_initialized = False
+        # This process must prove its own rollout/replay backend parity. The
+        # proof is intentionally absent from checkpoints because a resumed
+        # process may use different kernels, compilation, or batch geometry.
+        self._replay_parity_pending = True
+        self._precision_drift_guard_pending = True
+        self._update_phase_timers: list[PhaseTimer] = []
         self.rollout_schedule = build_rollout_schedule(
             self.config.rollout_orchestration,
             collector=self.collector,
@@ -1083,10 +1089,25 @@ class OnlineTrainer:
         with timer.time("advantage"):
             all_rewards = torch.cat([b.rewards for b in all_batches])
             all_group_ids = torch.cat([b.group_ids for b in all_batches])
-            advantages_all = self.algorithm.compute_advantages_from_tensors(
-                all_rewards,
-                all_group_ids,
-            )
+            if isinstance(self.algorithm, ComponentAdvantageAlgorithm):
+                component_tensors = {
+                    name: torch.as_tensor(
+                        values,
+                        dtype=all_rewards.dtype,
+                        device=all_rewards.device,
+                    )
+                    for name, values in reward_components.items()
+                }
+                advantages_all = self.algorithm.compute_advantages_from_components(
+                    all_rewards,
+                    component_tensors,
+                    all_group_ids,
+                )
+            else:
+                advantages_all = self.algorithm.compute_advantages_from_tensors(
+                    all_rewards,
+                    all_group_ids,
+                )
             # Per-prompt grouping stats for logging (mean group size + unique prompts).
             _unique_groups, _group_counts = torch.unique(all_group_ids, return_counts=True)
             group_size = (
@@ -1315,6 +1336,7 @@ class OnlineTrainer:
         """Start one streaming optimizer update: reset grads + metric accumulator."""
         self._update_optimizer = self._ensure_optimizer()
         self._update_ema = self._ensure_ema()
+        self._update_phase_timers.clear()
         self.model.train()
         self._update_agg_metrics = _ReplayMetrics()
         self._update_had_training_work = False
@@ -1338,8 +1360,8 @@ class OnlineTrainer:
         The single body behind both the streaming microbatch path and the
         full-batch PPO-epoch path — the two hand-copies drifted once
         (the all-filtered initial_replay crash), so the sweep lives here and
-        the callers keep only their own orchestration. ``timer`` is the
-        full-batch profiler; the streaming path times at a coarser grain.
+        the callers keep only their own orchestration. Both paths pass their
+        batch profiler so replay and backward timings share the same boundary.
         """
 
         cfg = self.config
@@ -1404,6 +1426,8 @@ class OnlineTrainer:
         from vrl.algorithms.trajectory import AlgorithmAdapter
 
         cfg = self.config
+        if cfg.profile:
+            self._update_phase_timers.append(batch.timer)
         # Unanimous skip across ranks: a backward fires cross-rank collectives, so
         # one rank skipping an empty microbatch while another runs it deadlocks
         # (see _all_ranks_have_work). Called once per microbatch on every rank, in
@@ -1422,6 +1446,13 @@ class OnlineTrainer:
             cfg.timestep_fraction,
             cfg.timestep_selection,
         )
+        samples_per_replay_batch = cfg.batch_plan.samples_per_replay_batch
+        first_batch = _training_sample_batches(
+            batch.batches[0],
+            batch.advantages[0],
+            samples_per_replay_batch,
+        )[0]
+        self._check_initial_precision_drift(first_batch.batch, train_indices)
         self._run_replay_pass(
             batch.batches,
             batch.advantages,
@@ -1431,6 +1462,7 @@ class OnlineTrainer:
             agg=self._update_agg_metrics,
             capture_initial_replay=True,
             defer_replay_tensors=defer,
+            timer=batch.timer,
         )
 
     async def finish_optimizer_update(
@@ -1455,13 +1487,15 @@ class OnlineTrainer:
         optimizer = self._update_optimizer
         agg = self._update_agg_metrics
         sync_stats = RolloutStats()
+        optimizer_timer = PhaseTimer(enabled=self.config.profile)
         if self._update_had_training_work:
-            local_initial, local_weight = agg.initial_replay_snapshot()
-            initial_replay = self._validate_first_update_parity(
-                local_initial,
-                local_weight=local_weight,
-            )
-            grad_norm, stepped = self._clip_and_step(optimizer)
+            with optimizer_timer.time("optim_step"):
+                local_initial, local_weight = agg.initial_replay_snapshot()
+                initial_replay = self._validate_first_update_parity(
+                    local_initial,
+                    local_weight=local_weight,
+                )
+                grad_norm, stepped = self._clip_and_step(optimizer)
             agg.grad_norms.append(grad_norm)
             if stepped:
                 after_optimizer_step = getattr(self.algorithm, "after_optimizer_step", None)
@@ -1487,9 +1521,13 @@ class OnlineTrainer:
 
         metric_step = self.state.step
         self.state.step += 1
+        stats.add_phases(optimizer_timer.times)
         stats.merge(sync_stats)
         if self.config.profile:
             self._stats_sink.record(metric_step, stats)
+            for timer in (*self._update_phase_timers, optimizer_timer):
+                self._write_phase_events(timer, step=metric_step)
+            self._update_phase_timers.clear()
         phase_times = stats.as_phase_dict()
         metrics = agg.build(
             reward_mean=reward_mean,
@@ -1624,7 +1662,7 @@ class OnlineTrainer:
             _ratio = torch.exp(_dbg_log_prob - _old_lp_0)
             _old_lp_first = _old_lp_0.reshape(-1)[0]
             _fresh_lp_first = _dbg_log_prob.reshape(-1)[0]
-            _parity_limit = float(cfg.debug.max_abs_logprob_diff)
+            _parity_limit = float(cfg.replay_parity.max_abs_logprob_diff)
             _local_parity_finite = bool(
                 torch.isfinite(_old_lp_0).all().item()
                 and torch.isfinite(_dbg_log_prob).all().item()
@@ -1671,22 +1709,13 @@ class OnlineTrainer:
                 },
                 "runtime_debug": _dbg_batch.context.get("runtime_debug"),
             }
-            # Replay parity is the ratio==1 invariant: with unchanged weights
-            # the fresh log-prob must reproduce the collection-time one. Persist
-            # the failing evidence before aborting so NaN/Inf cannot exploit a
-            # false comparison and train a corrupted policy.
+            # Persist a failing probe immediately: the mandatory full-update
+            # gate below owns enforcement, while this optional probe owns the
+            # tensor/provenance evidence needed to diagnose that failure.
             if not _parity_passed and self._strategy.context.is_primary:
                 append_jsonl_record(
                     f"{cfg.output_dir}/training_debug.jsonl",
                     first_step_debug_record,
-                )
-            if not _parity_passed:
-                raise RuntimeError(
-                    "first-step log-prob parity failed before optimizer step: "
-                    f"finite={_parity_finite}, max_abs_diff={_parity_max:.6g}, "
-                    f"limit={_parity_limit:.6g}. Replay does not reproduce rollout "
-                    "log-probs; check role precision, conditioning, and the "
-                    "scheduler domain.",
                 )
         elif cfg.debug.first_step and self.state.step == 0:
             # Non-evaluator algorithms (NFT) compute no log-prob ratio, so the
@@ -1739,72 +1768,9 @@ class OnlineTrainer:
                     },
                 }
 
-        # Precision drift guard: on the first step (before any optimizer update),
-        # check rollout-vs-replay logprob parity. `auto` protects unsafe precision
-        # splits; explicit warn/fail is used for same-precision acceptance runs.
-        if self.state.step == 0 and uses_evaluator and self.evaluator is not None:
-            _guard_batch = move_training_batch_to_device(
-                first_debug_batch.batch,
-                self.device,
-                defer_replay_tensors=defer_replay_tensor_move,
-            )
-
-            def _guard_evaluate(timestep_idx: int) -> TrajectorySignalBatch:
-                with (
-                    torch.no_grad(),
-                    profile_range("trainer.replay"),
-                ):
-                    _sig = self.evaluator.evaluate(
-                        self.model,
-                        _guard_batch,
-                        timestep_idx,
-                        ref_model=self.ref_model,
-                        signal_request=SignalRequest(
-                            need_ref=False,
-                            need_kl_intermediates=False,
-                        ),
-                    )
-                if not isinstance(_sig, TrajectorySignalBatch):
-                    raise TypeError(
-                        "evaluator output must be TrajectorySignalBatch; "
-                        f"got {type(_sig).__name__}",
-                    )
-                return _sig
-
-            _guard_record = measure_precision_drift(
-                cfg.precision_drift_guard,
-                training_precision=precision_metadata["training_precision"],
-                rollout_precision=precision_metadata["rollout_precision"],
-                math_precision=precision_metadata["math_precision"],
-                timestep_indices=train_indices,
-                evaluate_fn=_guard_evaluate,
-                metadata=precision_metadata,
-            )
-            if _guard_record is not None:
-                _worst = dict(_guard_record.get("worst_stats") or {})
-                _worst["logprob_abs_diff_max"] = _distributed_max_float(
-                    float(_worst.get("logprob_abs_diff_max", 0.0)),
-                    self.device,
-                )
-                _worst["ratio_abs_dev_max"] = _distributed_max_float(
-                    float(_worst.get("ratio_abs_dev_max", 0.0)),
-                    self.device,
-                )
-                _worst["finite"] = _distributed_all_true(
-                    bool(_worst.get("finite", True)),
-                    self.device,
-                )
-                _guard_record["worst_stats"] = _worst
-                _guard_record["violated"] = not _distributed_all_true(
-                    not bool(_guard_record["violated"]),
-                    self.device,
-                )
-                # Fail mode runs on every rank after the shared verdict; warn mode
-                # logs once so distributed runs do not race on duplicate output.
-                if _guard_record["mode"] == "fail" or self._strategy.context.is_primary:
-                    enforce_precision_drift(_guard_record, logger=logger)
-            if _guard_record is not None and first_step_debug_record is not None:
-                first_step_debug_record["precision_drift_guard"] = _guard_record
+        guard_record = self._check_initial_precision_drift(first_debug_batch.batch, train_indices)
+        if guard_record is not None and first_step_debug_record is not None:
+            first_step_debug_record["precision_drift_guard"] = guard_record
 
         initial_replay = InitialReplayStats()
         policy_updated = False
@@ -1965,13 +1931,96 @@ class OnlineTrainer:
         if not is_dummy:
             agg.add_sft(float(sft_term.detach()), float(loss_weight))
 
+    def _check_initial_precision_drift(
+        self,
+        batch: RolloutBatch,
+        timestep_indices: Sequence[int],
+    ) -> dict[str, Any] | None:
+        """Enforce the same first-trainable-batch guard on both update paths.
+
+        Precision correction deliberately permits non-exact replay, so its
+        bounded drift guard must also run during streaming accumulation. Callers
+        agree across ranks that training work exists before entering this gate.
+        """
+
+        from vrl.rollouts.evaluators.types import SignalRequest, TrajectorySignalBatch
+        from vrl.utils.profiling import profile_range
+
+        if (
+            not self._precision_drift_guard_pending
+            or not self.algorithm.uses_evaluator
+            or self.evaluator is None
+        ):
+            return None
+        cfg = self.config
+        precision_metadata = _trainer_precision_metadata(cfg, self.model, self.evaluator)
+        guard_batch = move_training_batch_to_device(
+            batch,
+            self.device,
+            defer_replay_tensors=bool(
+                getattr(self.evaluator, "supports_deferred_replay_tensor_move", False),
+            ),
+        )
+
+        def evaluate(timestep_idx: int) -> TrajectorySignalBatch:
+            with torch.no_grad(), profile_range("trainer.replay"):
+                signals = self.evaluator.evaluate(
+                    self.model,
+                    guard_batch,
+                    timestep_idx,
+                    ref_model=self.ref_model,
+                    signal_request=SignalRequest(need_ref=False, need_kl_intermediates=False),
+                )
+            if not isinstance(signals, TrajectorySignalBatch):
+                raise TypeError(
+                    "evaluator output must be TrajectorySignalBatch; "
+                    f"got {type(signals).__name__}",
+                )
+            return signals
+
+        record = measure_precision_drift(
+            cfg.precision_drift_guard,
+            training_precision=precision_metadata["training_precision"],
+            rollout_precision=precision_metadata["rollout_precision"],
+            math_precision=precision_metadata["math_precision"],
+            timestep_indices=timestep_indices,
+            evaluate_fn=evaluate,
+            metadata=precision_metadata,
+        )
+        if record is not None:
+            worst = dict(record.get("worst_stats") or {})
+            worst["logprob_abs_diff_max"] = _distributed_max_float(
+                float(worst.get("logprob_abs_diff_max", 0.0)),
+                self.device,
+            )
+            worst["ratio_abs_dev_max"] = _distributed_max_float(
+                float(worst.get("ratio_abs_dev_max", 0.0)),
+                self.device,
+            )
+            worst["finite"] = _distributed_all_true(
+                bool(worst.get("finite", True)),
+                self.device,
+            )
+            record["worst_stats"] = worst
+            record["violated"] = not _distributed_all_true(
+                not bool(record["violated"]),
+                self.device,
+            )
+            # Fail on every rank; warn and persist evidence only on the writer.
+            if record["mode"] == "fail" or self._strategy.context.is_primary:
+                enforce_precision_drift(record, logger=logger)
+            if self._strategy.context.is_primary:
+                append_jsonl_record(f"{cfg.output_dir}/training_debug.jsonl", record)
+        self._precision_drift_guard_pending = False
+        return record
+
     def _validate_first_update_parity(
         self,
         local: InitialReplayStats,
         *,
         local_weight: float,
     ) -> InitialReplayStats:
-        """Return the global initial snapshot and validate it before optimizer.step."""
+        """Gate this process's first measured exact replay before optimizer.step."""
 
         cfg = self.config
         resolved, has_measurements = _distributed_initial_replay_stats(
@@ -1979,12 +2028,17 @@ class OnlineTrainer:
             local_weight=local_weight,
             device=self.device,
         )
+        correction = getattr(self.algorithm, "precision_correction", None)
+        intentional_correction = correction is not None and (
+            correction.tis_mode != "off"
+            or correction.rs_mode != "off"
+            or correction.recompute_old_logprob != "off"
+        )
         if (
-            not cfg.debug.first_step
-            or self.state.step != 0
-            or self.state.global_step != 0
+            not self._replay_parity_pending
             or self.evaluator is None
             or not self.algorithm.uses_evaluator
+            or intentional_correction
         ):
             return resolved
 
@@ -1993,10 +2047,10 @@ class OnlineTrainer:
         if not has_measurements:
             return resolved
 
-        limit = float(cfg.debug.max_abs_logprob_diff)
+        limit = float(cfg.replay_parity.max_abs_logprob_diff)
         passed = resolved.finite and resolved.logprob_abs_diff_max <= limit
         record = {
-            "event": "first_step_full_logprob_parity",
+            "event": "replay_parity_gate",
             "passed": passed,
             "finite": resolved.finite,
             "max_abs_diff": resolved.logprob_abs_diff_max,
@@ -2009,13 +2063,14 @@ class OnlineTrainer:
             append_jsonl_record(f"{cfg.output_dir}/training_debug.jsonl", record)
         if not passed:
             raise RuntimeError(
-                "full first-step log-prob parity failed before optimizer step: "
+                "replay parity failed before this process's first optimizer update: "
                 f"finite={resolved.finite}, "
                 f"max_abs_diff={resolved.logprob_abs_diff_max:.6g}, "
                 f"limit={limit:.6g}. The first-sample probe is insufficient; "
                 "align rollout/replay precision and batch shape or recompute "
                 "the old policy with the replay backend.",
             )
+        self._replay_parity_pending = False
         return resolved
 
     @property
@@ -2041,19 +2096,15 @@ class OnlineTrainer:
         import torch.nn.functional as F
 
         from vrl.math.denoise.flow_matching import diffusion_pretraining_pair
+        from vrl.trainers.data.sft_latents import resolve_clean_target
         from vrl.trajectory import TrajectoryResolver
 
         assert self._sft_latents is not None  # ctor validated
         reward_metadata = group_batch.context.get("reward_metadata", {})
-        target_key = str(reward_metadata.get("target_video", "") or "").strip()
-        if not target_key:
-            raise ValueError(
-                "the sft regularizer needs batch.context.reward_metadata.target_video "
-                "to identify the clean target latent; this collector did not attach it",
-            )
+        target_key = resolve_clean_target(reward_metadata).key
         if target_key not in self._sft_latents:
             raise ValueError(
-                f"data.sft_latents has no entry for target_video {target_key!r}; "
+                f"data.sft_latents has no entry for clean target {target_key!r}; "
                 "re-encode the shard over the full training manifest",
             )
         scheduler = getattr(self.evaluator, "scheduler", None)
@@ -2102,7 +2153,7 @@ class OnlineTrainer:
         noise = torch.randn_like(x0)
         noisy, target = diffusion_pretraining_pair(scheduler, x0, noise, t)
         values = self.model.replay_forward_with_latents(group_batch, step_idx, noisy)
-        model_pred = values["noise_pred"]
+        model_pred = self.model.diffusion_pretraining_prediction(values)
         return self._sft_weight * F.mse_loss(model_pred.float(), target.float())
 
     def _shared_sft_step_index(self, num_steps: int) -> int:
@@ -2292,6 +2343,8 @@ class OnlineTrainer:
         # next Ray rollout. The policy version and worker state are runtime
         # concerns, not persisted as an initialized rollout flag.
         self._rollout_weights_initialized = False
+        self._replay_parity_pending = True
+        self._precision_drift_guard_pending = True
         self.rollout_schedule.reset()
 
     def _optimizer_parameter_manifest(self) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Review stack: 1 of 3

Base: `main`. Review and merge this PR before the reward and Anima layers.
Nothing in this stack enables auto-merge or pushes directly to `main`.

Stack: #16 (this PR) → #17 (rewards) → #18 (Anima experiments).

## Changes

- Make grouped advantage estimation configuration-owned and support per-component
  reward normalization while preserving the scalar path.
- Enforce unchanged-policy replay parity before the first optimizer update,
  including after resume, and share the precision guard across streaming and
  ordinary updates. Keep upstream replay-loop and distributed-statistics deduplication.
- Support image/video clean-target identities and model-owned pretraining
  predictions for diffusion-loss regularization, including Anima's conditional velocity.
- Separate typed reward deployment settings from constructor arguments; carry
  stable sample/group identities through collection and reward services.
- Add ordered `+group=option` composition and an unresolved inspection boundary
  for config linting; keep the existing execution recipes in this first layer.
- Preserve the pending local Wan HPSv3 recipe/evaluation changes while integrating
  all 17 commits that were already on remote main.
- Normalize the historical SANA parity-key spelling at the persisted report boundary.
  The frozen digest is unchanged; conflicting keys and changed thresholds still fail.
- Run PR CI for `review/**` base branches so the dependent stack also gets checks.

## Compatibility / review focus

- Reward clients and servers must be upgraded together: wire protocol v4 requires
  `sample_id`.
- Move transport from `reward.kwargs.<component>.inference` to
  `reward.inference.<component>`.
- Live training uses `trainer.replay_parity.max_abs_logprob_diff`, not the former
  debug field. Historical spelling is accepted only by the SANA report adapter.
- The shared model seam, typed clean-target identity, reward schema key, and
  configuration inspection facade are intentional boundaries, not wrappers to flatten.
- No training-quality improvement is claimed from CPU validation.

## Verification

- This layer alone: 1,097 CPU tests passed, 2 deselected.
- Configuration source/YAML lint passed, including the still-existing Anima recipes.
- SANA checkpoint/curve/comparison protocol tests passed without changing the
  registered protocol digest.
- Final-stack targeted Ruff lint/format checks and diff checks passed.

The subsequent PRs add reusable reward scorers, then composed Anima experiments,
evaluation tools, prompt manifests, and research records.
